### PR TITLE
update: gitignore for jupyter and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,45 @@
 SNT_extract_changes.txt
 SNT Process/
 .vscode/
+
+
+# Jupyter stuff -------------------------
+
+# Windows security metadata files attached to Jupyter notebooks
+# (on Linux and macOS, this pattern has no effect)
+*.ipynb:Zone.Identifier
+
+# Ignore Jupyter Notebook checkpoints
+*.ipynb_checkpoints/
+
+
+# Test and temporary stuff ------------------------
+**/old/
+**/ignore/
+**/test/
+**/to_find_better_place/
+**/WIP/
+**/tmp/
+**/test_stuff*
+**/[Tt]est*
+
+# Avoid sharing sensitive data --------------------
+*.csv
+*.CSV
+*.xlsx
+*.xls
+*.yaml
+*.yml
+
+# Config file -----------------
+# ignore .json files unless if SNT_config.json
+*.json
+!SNT_config.json
+
+# R ----------------------------------------
+*.rds
+*.RDS 
+# except any R script 
+!*.R
+!*.r 
+


### PR DESCRIPTION
Make tracking easier if we can by default ignore certain files. 
I don't see any issues, but I thought you might want to double check ...