### PR TITLE
bug(incidence): fail if selected disaggregated pop missing

### DIFF
--- a/pipelines/snt_dhis2_incidence/utils/snt_dhis2_incidence.r
+++ b/pipelines/snt_dhis2_incidence/utils/snt_dhis2_incidence.r
@@ -162,6 +162,10 @@ return(head(dhis2_population_adm2, 3))
 # --- DISAGGREGATION LOGIC --- --- --- --- --- --- ---
 
 prepare_disaggregated_indicators <- function(dhis2_routine, DISAGGREGATION_SELECTION, N1_METHOD) {
+
+  # Initial log msg
+    log_msg(glue::glue("Starting preparation of disaggregated indicators for selection '{DISAGGREGATION_SELECTION}' and N1_METHOD '{N1_METHOD}'."))
+
   # Initialize the flag locally
   DISAGGREGATED_INDICATORS_FOUND <<- FALSE 
 
@@ -171,6 +175,7 @@ prepare_disaggregated_indicators <- function(dhis2_routine, DISAGGREGATION_SELEC
     prefix_fixed <- c("TEST", "CONF") 
     prefix_all    <- c(prefix_method, prefix_fixed) 
     target_colnames <<- glue::glue("{prefix_all}_{DISAGGREGATION_SELECTION}")
+    log_msg(glue::glue("Looking for disaggregated indicators columns in routine data: {paste(target_colnames, collapse=', ')}"))
     
     if (all(target_colnames %in% colnames(dhis2_routine))) {
       # Map the disaggregated columns (e.g., SUSP_UNDER_5) to generic names (e.g., SUSP) so that 
@@ -178,44 +183,45 @@ prepare_disaggregated_indicators <- function(dhis2_routine, DISAGGREGATION_SELEC
       dhis2_routine[prefix_all] <- dhis2_routine[target_colnames]
       
       for (col in target_colnames) {
-        log_msg(glue::glue("Population Disaggregation: Successfully mapped indicator: {col}"))
+        log_msg(glue::glue("Indicator Disaggregation: Successfully mapped indicator {col}"))
       }    
       
       # Signal success for the next code block
       DISAGGREGATED_INDICATORS_FOUND <<- TRUE 
     } else {
       missing_cols <- setdiff(target_colnames, colnames(dhis2_routine))
-      log_msg(glue::glue("Population Disaggregation: Disaggregation on '{DISAGGREGATION_SELECTION}' failed."), "warning")
-      log_msg(glue::glue("Population Disaggregation: Missing columns in routine dataset: {paste(missing_cols, collapse = ', ')}"), "warning")
-      msg <- glue::glue("[ERROR] 🛑 Population Disaggregation: Required columns for disaggregation '{DISAGGREGATION_SELECTION}' are missing.")  
+      log_msg(glue::glue("Indicator Disaggregation: Disaggregation on '{DISAGGREGATION_SELECTION}' failed."), "warning")
+      log_msg(glue::glue("Indicator Disaggregation: Missing columns in routine dataset: {paste(missing_cols, collapse = ', ')}"), "warning")
+      msg <- glue::glue("[ERROR] 🛑 Indicator Disaggregation: Required columns for disaggregation '{DISAGGREGATION_SELECTION}' are missing.")  
       stop(msg)
     }
   } else {
     # Print just in nb (not in pipeline logs)
-    print("Population Disaggregation: No disaggregation applied based on the current configuration.")
+    print("Indicator Disaggregation: No disaggregation applied based on the current configuration.")
   }
   # return(dhis2_routine)
     dhis2_routine <<- dhis2_routine
 }
 
+# Rewrote select_population_column() to be mapping the DISAGGREGATION_SELECTION 
+# only if it exists in the population dataset, otherwise log an error and break 
+# (instead of silently using the non-disaggregated population)
 select_population_column <- function(dhis2_population_adm2, DISAGGREGATED_INDICATORS_FOUND, DISAGGREGATION_SELECTION) {
-  # Default value for the selection if the condition isn't met or if it fails
-  POPULATION_SELECTION <<- "POPULATION"
   if (DISAGGREGATED_INDICATORS_FOUND) { 
-      POPULATION_SELECTION <<- paste0("POP_", DISAGGREGATION_SELECTION)    
-      if (!(POPULATION_SELECTION %in% colnames(dhis2_population_adm2))) {
-          log_msg(glue::glue("Population Disaggregation: Column '{POPULATION_SELECTION}' not found in Population dataset."), "warning")
-          POPULATION_SELECTION <<- "POPULATION"
+      POPULATION_SELECTION <- paste0("POP_", DISAGGREGATION_SELECTION) 
+      if (POPULATION_SELECTION %in% colnames(dhis2_population_adm2)) {   
+        # The selected column is assigned to POPULATION col so that later code can use it generically
+        dhis2_population_adm2$POPULATION <- dhis2_population_adm2[[POPULATION_SELECTION]]
+        log_msg(glue::glue(
+            "Population Disaggregation: Column '{POPULATION_SELECTION}' selected as population values, 
+            and renamed to 'POPULATION'."))
+      } else {
+          log_msg(glue::glue("Population Disaggregation: Column '{POPULATION_SELECTION}' not found in Population dataset!"), "error")
+          stop(glue::glue("Population Disaggregation: Column '{POPULATION_SELECTION}' not found in Population dataset!"))
       }
-      # The selected column is assigned to POPULATION col so that later code can use it generically
-      dhis2_population_adm2$POPULATION <- dhis2_population_adm2[[POPULATION_SELECTION]]
-      log_msg(glue::glue("Population Disaggregation: Column '{POPULATION_SELECTION}' selected as population values."))
-  } else {
-    # Print just in nb (not in pipeline logs)
-    print("Population Disaggregation: No disaggregation applied based on the current configuration.")
   }
-    dhis2_population_adm2 <<- dhis2_population_adm2
 }
+
 
 # --- --- --- --- --- --- --- --- ---
 

--- a/pipelines/snt_seasonality_rainfall/code/snt_seasonality_rainfall_NER.ipynb
+++ b/pipelines/snt_seasonality_rainfall/code/snt_seasonality_rainfall_NER.ipynb
@@ -1,0 +1,1951 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "8614890a",
+      "metadata": {},
+      "source": [
+        "**Code commented and slightly modified by Giulia.**\n",
+        "\n",
+        "The changes do _not_ affect the core calculations! I simply added explanations and/or moved things around **for the sake of readability**.\n",
+        "\n",
+        "Added new version of fun `compute_month_seasonality()` -> `compute_month_seasonality_NEW()` to allow choice of calendar year for denominator\n",
+        "If good this function should be moved to \"snt_utils.R\" (or, if only used in this nb, keep here and bring out of function for readability)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c675bc1c",
+      "metadata": {},
+      "source": [
+        "-------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2ce6afdc",
+      "metadata": {},
+      "source": [
+        "## **Rainfall Seasonality**<br>\n",
+        "The pipeline employs a four-step hierarchical method to classify administrative units (`ADM2`) as **seasonal**, determine the **duration** of their rainy season, and identify the respective **onset month**. \n",
+        "\n",
+        "#### **1. Identify \"start\" month**\n",
+        "The first step evaluates every specific month in the dataset (per district and year) to determine if it marks the beginning of a concentrated rainfall period.<br>\n",
+        "**Logic**: For each month, the pipeline calculates a \"forward-looking\" proportion: the ratio of rainfall in the next {n}-month block (e.g., 3, 4, or 5 months) to the total rainfall of the following 12 months (rolling annual sum).<br>\n",
+        "**Threshold**: If this proportion exceeds the defined `threshold_for_seasonality` (e.g., **60%**), the month is flagged as a valid \"start\" month (`RAINFALL_{n}_MTH_ROW_SEASONALITY = 1`). This indicates that the majority of the annual rain falls within the block starting that month.\n",
+        "\n",
+        "#### **2. Classify an `ADM2` as \"Seasonal\" or \"Non-seasonal\"**\n",
+        "The second step aggregates the month-level \"start of the block\" flags to determine if the **district (`ADM2`) _consistently_** experiences a rainy season (of a specific duration).<br>\n",
+        "**Logic**: The data is grouped by `ADM2_ID` and `MONTH` to calculate the **frequency** (proportion of `YEAR`s) that a specific month was flagged as a \"start\" in Step 1.<br>\n",
+        "**Consistency**: If this frequency exceeds the `proportion_seasonal_years_threshold` (e.g., **70%**), the district is officially classified as \"Seasonal\" for that block duration (`SEASONALITY_RAINFALL_{n}_MTH = 1`). This ensures that the seasonality is a recurring climatic feature rather than a one-off event.\n",
+        "\n",
+        "#### **3. Determine season _duration_**\n",
+        "The third step **resolves cases where a district qualifies as seasonal for multiple block durations** (e.g., it meets the criteria for both 4-month and 5-month blocks).<br>\n",
+        "**Logic**: The pipeline compares all valid block sizes for the district and selects the minimum duration (SEASONAL_BLOCK_DURATION_RAINFALL).<br>\n",
+        "**Outcome**: This defines the **shortest window** in which the required proportion of annual rainfall is concentrated.\n",
+        "\n",
+        "#### **4. Determine season _onset_**\n",
+        "The final step identifies the **_single_ official start month** for the defined season.<br>\n",
+        "**Logic**: Using the valid seasonal years identified in the previous steps, the pipeline calculates the **Mode** (most frequent value) of the start months.<br>\n",
+        "**Outcome**: The specific month that appears most frequently as the \"start\" across the historical data is assigned as the `SEASONAL_BLOCK_START_MONTH`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0b707d8a",
+      "metadata": {},
+      "source": [
+        "--------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9445be56",
+      "metadata": {},
+      "source": [
+        "## Parameters"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "522b1e30",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "source": [
+        "(GP) ⭐ NEW PARAMETER for Step **1. Identify \"start\" month**: define method to calculate **denominator**\n",
+        "\n",
+        "Choices:\n",
+        "* `FALSE` uses the original approach coded by **Iulia** (follows **WHO** recommendations): rolling 12-month forward window \n",
+        "* `TRUE` uses **Bea**'s (AHADI) approach: \"calendar\" year (January to December)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "89502808",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# MOVED to \"new_parameter.r\" to be used across seasonality notebooks\n",
+        "\n",
+        "# USE_CALENDAR_YEAR_DENOMINATOR <- TRUE\n",
+        "\n",
+        "# # Create suffix to be added to all exported objects (so we can compare outputs)\n",
+        "# if (USE_CALENDAR_YEAR_DENOMINATOR) {\n",
+        "#   SUFFIX <- \"_calendar\"\n",
+        "# } else {\n",
+        "#   SUFFIX <- \"_frollsum\"\n",
+        "# }"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "aaa0b30f",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "source(\"~/workspace/pipelines/snt_seasonality_rainfall/code/new_parameter.r\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f9781e2d",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "source": [
+        "Original parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ac7ad327",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Fallback values - for local Development only!\n",
+        "\n",
+        "if (!exists(\"minimum_month_block_size\")) {\n",
+        "  minimum_month_block_size <- as.integer(3)\n",
+        "}\n",
+        "\n",
+        "if (!exists(\"maximum_month_block_size\")) {\n",
+        "  maximum_month_block_size <- as.integer(5)\n",
+        "}\n",
+        "\n",
+        "if (!exists(\"threshold_for_seasonality\")) {\n",
+        "  threshold_for_seasonality <- 0.6\n",
+        "}\n",
+        "\n",
+        "if (!exists(\"threshold_proportion_seasonal_years\")) {\n",
+        "  threshold_proportion_seasonal_years <- 0.7\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "48b73808",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "minimum_month_block_size <- as.integer(minimum_month_block_size)\n",
+        "maximum_month_block_size <- as.integer(maximum_month_block_size)\n",
+        "\n",
+        "# New by GP\n",
+        "print(paste(\"Minimum month block size: \", minimum_month_block_size))\n",
+        "print(paste(\"Maximum month block size: \", maximum_month_block_size))  "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ac432c54",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP: moved this up\n",
+        "\n",
+        "possible_month_block_sizes <- as.integer(minimum_month_block_size:maximum_month_block_size)\n",
+        "formatted_threshold_for_seasonality <- sprintf(\"%d%%\", round(threshold_for_seasonality * 100))\n",
+        "\n",
+        "print(paste(\"Possible month block sizes:\", paste(possible_month_block_sizes, collapse = \", \")))\n",
+        "print(paste(\"Seasonality threshold (formatted):\",formatted_threshold_for_seasonality))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "543f9451",
+      "metadata": {},
+      "source": [
+        "These 👇 are used in \"**Quality check on data completeness**\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5d87891c",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "minimum_periods <- as.integer(48)\n",
+        "maximum_proportion_missings_overall <- 0.1\n",
+        "maximum_proportion_missings_per_district <- 0.2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "071a7bc6",
+      "metadata": {},
+      "source": [
+        "#### **Fixed routine formatting columns**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "33b2eb7d",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Global variables\n",
+        "type_of_seasonality <- \"rainfall\"\n",
+        "data_source <- 'ERA5'\n",
+        "original_values_col <- 'MEAN'\n",
+        "\n",
+        "# space and time columns\n",
+        "admin_level <- 'ADM2'\n",
+        "admin_id_col <- paste(admin_level, toupper('id'), sep = '_')\n",
+        "admin_name_col <- paste(admin_level, toupper('name'), sep = '_')\n",
+        "year_col <- 'YEAR' # GP: this can be skipped (make more explicit) as we always use same col names across SNT toolbox\n",
+        "month_col <- 'MONTH' # GP: this can be skipped (make more explicit) as we always use same col names across SNT toolbox\n",
+        "period_cols <- c(year_col, month_col)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5eebc540-e973-497e-8427-e73d546fdd09",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "source": [
+        "## Preliminaries (Set up)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7d9634ff",
+      "metadata": {},
+      "source": [
+        "#### Paths"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a6915379-108e-4405-b553-b074aad447d6",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Paths\n",
+        "ROOT_PATH <- '~/workspace'\n",
+        "CONFIG_PATH <- file.path(ROOT_PATH, 'configuration')\n",
+        "CODE_PATH <- file.path(ROOT_PATH, 'code')\n",
+        "DATA_PATH <- file.path(ROOT_PATH, 'data')\n",
+        "OUTPUT_DATA_PATH <- file.path(DATA_PATH, 'seasonality_rainfall')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "da24d306",
+      "metadata": {},
+      "source": [
+        "#### Env and Packages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "18d197b6-9de8-4e4b-bc4e-8b452de67287",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Global settings\n",
+        "options(scipen=999)\n",
+        "\n",
+        "Sys.setenv(PROJ_LIB = \"/opt/conda/share/proj\")\n",
+        "Sys.setenv(GDAL_DATA = \"/opt/conda/share/gdal\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f94d1e6c-0675-4349-b6e0-a28197c8c9e4",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Load utils\n",
+        "source(file.path(CODE_PATH, \"snt_utils.r\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "180b93e7-61af-4981-863f-593b755968bd",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# List required pcks\n",
+        "required_packages <- c(\n",
+        "  \"jsonlite\",\n",
+        "  \"data.table\",\n",
+        "  \"ggplot2\",\n",
+        "  \"fpp3\",\n",
+        "  \"arrow\",\n",
+        "  \"glue\",\n",
+        "  \"sf\",\n",
+        "  \"RColorBrewer\",\n",
+        "  \"httr\",\n",
+        "  \"reticulate\"\n",
+        ")\n",
+        "\n",
+        "# Execute function\n",
+        "install_and_load(required_packages)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "609cd062-d7d9-42de-976b-10f8a0bfc18a",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "Sys.setenv(RETICULATE_PYTHON = \"/opt/conda/bin/python\")\n",
+        "reticulate::py_config()$python\n",
+        "openhexa <- import(\"openhexa.sdk\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ba385bee",
+      "metadata": {},
+      "source": [
+        "#### Load SNT_config.json"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "458b3d65-cc7e-41bc-95fd-7011dcd5528f",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Load SNT config\n",
+        "CONFIG_FILE_NAME <- \"SNT_config.json\"\n",
+        "config_json <- tryCatch({ fromJSON(file.path(CONFIG_PATH, CONFIG_FILE_NAME)) },\n",
+        "    error = function(e) {\n",
+        "        msg <- paste0(\"Error while loading configuration\", conditionMessage(e))  \n",
+        "        cat(msg)   \n",
+        "        stop(msg) \n",
+        "    })\n",
+        "\n",
+        "msg <- paste0(\"SNT configuration loaded from  : \", file.path(CONFIG_PATH, CONFIG_FILE_NAME)) \n",
+        "log_msg(msg)\n",
+        "\n",
+        "# Set config variables\n",
+        "COUNTRY_CODE <- config_json$SNT_CONFIG$COUNTRY_CODE\n",
+        "era5_dataset <- config_json$SNT_DATASET_IDENTIFIERS$ERA5_DATASET_CLIMATE\n",
+        "dhis2_dataset <- config_json$SNT_DATASET_IDENTIFIERS$DHIS2_DATASET_FORMATTED\n",
+        "\n",
+        "print(paste(\"Country code: \", COUNTRY_CODE))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "86f492f3-5634-4987-a2b8-23014aba5d51",
+      "metadata": {},
+      "source": [
+        "## Load data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2d6ea0ce",
+      "metadata": {},
+      "source": [
+        "#### Shapes (as `spatial_data`)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "623480ee-4310-4ead-a8c8-bf294527c814",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Load spatial file from dataset\n",
+        "spatial_data_filename <- paste(COUNTRY_CODE, \"shapes.geojson\", sep = \"_\")\n",
+        "spatial_data <- get_latest_dataset_file_in_memory(dhis2_dataset, spatial_data_filename)\n",
+        "log_msg(glue(\"File {spatial_data_filename} successfully loaded from dataset version: {dhis2_dataset}\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ce9a4acf",
+      "metadata": {},
+      "source": [
+        "#### Rainfall (as `original_dt`)\n",
+        "Data produced by pipeline [D.2 ERA5 Aggregate](https://app.openhexa.org/workspaces/ner-snt-process/pipelines/d-2-era5-aggregate-eee33c/) \n",
+        "\n",
+        "Resolution:\n",
+        "* Spatial: `ADM2_ID`\n",
+        "* Temporal: `MONTH`\n",
+        "\n",
+        "Summarization of values of **mm of rainfall**: \n",
+        "* `MEAN`\n",
+        "* `MIN` & `MAX`\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1f766ea1-dced-4143-a5be-fdc51da4bd8d",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Load rainfall data from dataset\n",
+        "rainfall_data_filename <- paste(COUNTRY_CODE, \"total_precipitation_monthly.parquet\", sep = \"_\")\n",
+        "original_dt <- get_latest_dataset_file_in_memory(era5_dataset, rainfall_data_filename)\n",
+        "log_msg(glue(\"File {rainfall_data_filename} successfully loaded from dataset version: {era5_dataset}\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8935f2b8",
+      "metadata": {},
+      "source": [
+        "## Create scaffold for output table"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7b769deb-52e5-471d-9950-ac431dd8cf03",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Columns formatting\n",
+        "admin_data <- sf::st_drop_geometry(spatial_data) # same as `select(starts_with(\"ADM\"))`\n",
+        "setDT(admin_data) # convert to data.table for easier manipulation\n",
+        "common_cols <- names(admin_data) \n",
+        "\n",
+        "seasonality_col <- glue('SEASONALITY', toupper(type_of_seasonality), .sep = \"_\") \n",
+        "season_duration_col <- glue('SEASONAL_BLOCK_DURATION', toupper(type_of_seasonality), .sep = \"_\") # input of `compute_min_seasonality_block()`\n",
+        "season_start_month_col <- glue('SEASONAL_BLOCK_START_MONTH', toupper(type_of_seasonality), .sep = \"_\")\n",
+        "rain_proportion_col <- 'RAIN_PROPORTION'\n",
+        "final_table_cols <- c(names(admin_data), seasonality_col, season_duration_col, season_start_month_col, rain_proportion_col)\n",
+        "print(final_table_cols)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0d329af2-f544-4ee2-940f-65e2ab11c49d",
+      "metadata": {},
+      "source": [
+        "**Create the containers for the data**<br>\n",
+        "Create an empty table if the analysis is stopped for lack of enough data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "90486c1e-38bc-4c6f-bffe-b7e8f3be68ca",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Create an empty table if the analysis is stopped for lack of enough data\n",
+        "seasonality_cols <- c(seasonality_col, season_duration_col, season_start_month_col, rain_proportion_col)\n",
+        "empty_dt <- copy(admin_data)[, (seasonality_cols) := NA]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b8da71be-45f1-405c-857c-ed86984988f4",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "source": [
+        "## Pre-process Rainfall data \n",
+        "(`original_dt` = ERA5 Rainfall data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c5bf0faa-357e-44a7-af0c-04dd382af7e0",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# format table to define col types\n",
+        "setDT(original_dt) # ERA5 Rainfall data\n",
+        "integer_cols <- c(year_col, month_col)\n",
+        "numeric_cols <- c(original_values_col)\n",
+        "original_dt[, (integer_cols) := lapply(.SD, as.integer), .SDcols = integer_cols]\n",
+        "\n",
+        "head(original_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "894d667c",
+      "metadata": {},
+      "source": [
+        "### Quality check on data completeness\n",
+        "(🤔 GP: probably legacy of working with cases, not rainfall, as ERA5 rainfall data should always be complete ... ?)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a1a762ad-943e-467b-8cc1-e4998a996b9f",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# keep only the useful columns and aggregate the data on them\n",
+        "original_dt <- original_dt[,\n",
+        "                           setNames(list(sum(get(original_values_col), na.rm = TRUE)), original_values_col), \n",
+        "                           by = c(admin_id_col, period_cols)\n",
+        "                           ]\n",
+        "\n",
+        "num_periods <- make_cartesian_admin_period(original_dt, admin_id_col, year_col, month_col)[[1]]\n",
+        "all_rows <- make_cartesian_admin_period(original_dt, admin_id_col, year_col, month_col)[[2]]\n",
+        "\n",
+        "if (num_periods < minimum_periods){    \n",
+        "    log_msg(glue(\"Data is not reliable: \n",
+        "                    at least {minimum_periods} year-month periods of data are required for the case analyais; \n",
+        "                    the data only contains {num_periods} periods. Abandoning analysis.\")\n",
+        "           , level=\"error\")\n",
+        "    stop(\"ERROR 1\")\n",
+        "} else {\n",
+        "    log_msg(glue(\"The data contains {num_periods} unique month-year periods for each district, which is sufficient to proceed with the analysis.\"))\n",
+        "}\n",
+        "\n",
+        "# inject the (possibly missing) rows into the data\n",
+        "original_dt <- make_full_time_space_data(\n",
+        "  input_dt=original_dt,\n",
+        "  full_rows_dt=all_rows,\n",
+        "  target_colname=original_values_col,\n",
+        "  admin_colname=admin_id_col,\n",
+        "  year_colname=year_col,\n",
+        "  month_colname=month_col)\n",
+        "\n",
+        "# GP: made logic more explicit and added log messages\n",
+        "nr_missing_values <- nrow(original_dt[is.na(get(original_values_col)),])\n",
+        "threshold_nr_missing_values <- maximum_proportion_missings_overall * nrow(original_dt)\n",
+        "\n",
+        "# if(nrow(original_dt[is.na(get(original_values_col)),]) > (maximum_proportion_missings_overall * nrow(original_dt))){ # GP\n",
+        "if(nr_missing_values > threshold_nr_missing_values){    # GP\n",
+        "    log_msg(\"There are too many missing values in the data overall. Abandoning analysis.\", level=\"error\")\n",
+        "    stop(\"ERROR 2\")   \n",
+        "} else { # GP\n",
+        "    log_msg(glue(\"There are {nr_missing_values} missing values in the data, which is within the acceptable threshold of {threshold_nr_missing_values}. Proceeding with the analysis.\"))\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1f32cf7f",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Add log mesage to specify start and end of available data \n",
+        "yyyymm_min <- original_dt[, min(get(year_col)*100 + get(month_col), na.rm = TRUE)]\n",
+        "yyyymm_max <- original_dt[, max(get(year_col)*100 + get(month_col), na.rm = TRUE)]\n",
+        "period_range <- c(yyyymm_min, yyyymm_max)\n",
+        "log_msg(glue(\"Rainfall data (ERA5) available for the period range {period_range[1]} to {period_range[2]}.\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e3d793a5-ac96-4dcc-bd86-5837a631ea54",
+      "metadata": {},
+      "source": [
+        "### Imputation of missings"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1b7c767b-5343-4d7a-ad6a-aac11ee2ba12",
+      "metadata": {},
+      "source": [
+        "**Remove impute files (if any)**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6e3d8e9f",
+      "metadata": {},
+      "source": [
+        "### 🤌🏼: where are \"impute files\" from? Dedicated pipeline I assume ... Is this still relevant (or legacy code)?"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ac3414c6-baf1-47f0-ad6d-5ff1cb0e432e",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Remove existing imputation files\n",
+        "filename_imputed_dt <- paste(COUNTRY_CODE, type_of_seasonality, 'imputed.csv', sep = '_')\n",
+        "files_in_folder <- list.files(OUTPUT_DATA_PATH, full.names = TRUE)\n",
+        "files_to_remove <- files_in_folder[grepl(filename_imputed_dt, basename(files_in_folder), ignore.case = TRUE)]\n",
+        "file.remove(files_to_remove)\n",
+        "print(glue(\"Deleted files: {str(files_to_remove)}\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8cf34a4f-f429-4ee5-9919-5e5c7abe9da6",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# create the name of the column which will store the imputed/estimated values\n",
+        "imputed_col = paste(original_values_col, 'EST', sep = '_')\n",
+        "\n",
+        "# if there are rows of missing data for cases, impute them (SARIMA)\n",
+        "if(nrow(original_dt[!is.na(get(original_values_col)),]) != nrow(original_dt)) {\n",
+        "    log_msg(\"There is missing data. Proceeding to impute them.\", level=\"warning\")\n",
+        "    \n",
+        "    # extract data on only the administrative units which have missing values for original_values_col\n",
+        "    missing_dt <- extract_dt_with_missings(original_dt, target_colname = original_values_col, id_colname = admin_id_col)\n",
+        "    missing_dt <- missing_dt[, PERIOD := make_yearmonth(year = YEAR, month = MONTH)]\n",
+        "    missing_dt <- missing_dt[, .SD, .SDcols = c(admin_id_col, 'PERIOD', original_values_col)]\n",
+        "    \n",
+        "    # how many rows missing for each administrative unit? if too many, then not good idea to impute\n",
+        "    missings_by_admin_unit <- missing_dt[, .(missing_count = sum(is.na(get(original_values_col)))), by = admin_id_col][order(-missing_count)]\n",
+        "    \n",
+        "    # if for any given admin unit, more than a given % of data is missing, there's too much to impute (maybe should be stricter - to discuss)\n",
+        "    if(missings_by_admin_unit[, max(missing_count)] > maximum_proportion_missings_per_district * num_periods){\n",
+        "      log_msg(\"Some administrative units have too many missing values in the target data. Abandoning analysis.\", level=\"error\")\n",
+        "      stop(\"ERROR 3\")\n",
+        "    }\n",
+        "    \n",
+        "    # split to list per admin_unit_id, to apply SARIMA imputation on each time series (per admin unit)\n",
+        "    missing_districts_list <- split(missing_dt, by = admin_id_col)\n",
+        "    \n",
+        "    # seasonal ARIMA to estimate missing cases: apply function to list of data.tables with missing rows, then create data.table from result\n",
+        "    filled_missings_dt <- rbindlist(\n",
+        "    lapply(missing_districts_list,\n",
+        "           fill_missing_cases_ts,\n",
+        "           original_values_colname=original_values_col,\n",
+        "           estimated_values_colname=imputed_col,\n",
+        "           admin_colname=admin_id_col,\n",
+        "           period_colname='PERIOD',\n",
+        "           threshold_for_missing = 0.0)\n",
+        "    )\n",
+        "    \n",
+        "    # add the imputed (\"_EST\") values to the original data\n",
+        "    imputed_dt <- merge.data.table(original_dt, filled_missings_dt[, .SD, .SDcols = !(original_values_col)], by = c(admin_id_col, year_col, month_col), all.x = TRUE)\n",
+        "    \n",
+        "    # copy from the districts without missings;\n",
+        "    # if data is large, this could be made faster by only copying from the districts which are not in the missing_dt\n",
+        "    imputed_dt[!is.na(get(original_values_col)), (imputed_col) := get(original_values_col)]\n",
+        "\n",
+        "    # Save imputed file, only if it was computed..\n",
+        "    fwrite(imputed_dt, file = file.path(OUTPUT_DATA_PATH, filename_imputed_dt))\n",
+        "    \n",
+        "} else {\n",
+        "    imputed_dt <- copy(original_dt)\n",
+        "    imputed_dt[, (imputed_col) := get(original_values_col)]\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9db44942-d844-491c-9045-906e99a37c60",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "source": [
+        "## Evaluate Seasonality"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "17154eb2",
+      "metadata": {},
+      "source": [
+        "### 1. **Identify \"start\" month**\n",
+        "> _Is this **month** a **start**?_ \n",
+        "\n",
+        "(\"Row-Level Seasonality\")\n",
+        "\n",
+        "**Logic**:\n",
+        "* for each `MONTH`, calculate the **proportion** of **annual rainfall** falling in the next {n}-months \"**block**\" \n",
+        "    * With {n} defined by parameter `possible_month_block_sizes`\n",
+        "    * With **denominator** as the **rolling sum of the next 12 months** rainfall (moving window)\n",
+        "* if this proportion is > ***X%***, then that month is flagged as a \"**start**\" (of rain season) month\n",
+        "    * where: ***X%*** = the value of `threshold_for_seasonality` (e.g., 60%)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9e28b667",
+      "metadata": {},
+      "source": [
+        "The **output** of `compute_month_seasonality()` is a dt with the following cols:\n",
+        "* `ADM2_ID`, `YEAR`, `MONTH`\n",
+        "* `RAINFALL_SUM_12_MTH_FW`: the total accumulated rainfall (mm) for the **12-month** block starting from the current month\n",
+        "* `RAINFALL_SUM_{n}_MTH_FW`: the total accumulated rainfall (mm) for the **{n}-month** block starting from the current month\n",
+        "* `RAINFALL_{n}_MTH_ROW_PROP`: the **percentage** of the **annual rainfall** that falls within that specific {n}-month block.\n",
+        "    * Calculated as `RAINFALL_SUM_{n}_MTH_FW / RAINFALL_SUM_12_MTH_FW`\n",
+        "* `RAINFALL_{n}_MTH_ROW_SEASONALITY`: a **binary flag (1 or 0)** indicating whether this specific month qualifies as the start of a rainy season \"block\".\n",
+        "    * The **Logic**: It checks if the proportion calculated above is greater than or equal to the `threshold_for_seasonality` (e.g., 60%).\n",
+        "    * The **Interpretation**:\n",
+        "        * `1` (TRUE): \"If the season ({n}-months block) started in month X, it would contain at least 60% of the year's total rain. Therefore, month X is a valid candidate for the start of the season.\"\n",
+        "        * `0` (FALSE): \"The {n}-months block starting in month X do not contain enough of the year's total rain.\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "eca5f9c7",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# The seasonality per row (period-admin unit) -----------------------------\n",
+        "\n",
+        "row_seasonality_dt <- compute_month_seasonality(\n",
+        "  input_dt=imputed_dt, # The cleaned and valid rainfall data\n",
+        "  indicator=type_of_seasonality, # \"RAINFALL\" (legacy parameter name, we could simply spell it out now)\n",
+        "  values_colname=imputed_col, # \"MEAN_EST\" = mean rainfall (mm). \"_EST\" because it can be the original value or the imputed one, depending on the case\n",
+        "  vector_of_durations=possible_month_block_sizes, # pipeline param (e.g. 3, 4, 5 months)\n",
+        "  admin_colname=admin_id_col, # ADM2_ID (also could be hard-coded as it's always gonna be at AMD2 level ... )\n",
+        "  year_colname=year_col, # YEAR (also could be hard-coded as it's always gonna be the same col name across SNT toolbox ...)\n",
+        "  month_colname=month_col, # MONTH (also could be hard-coded as it's always gonna be the same col name across SNT toolbox ...)\n",
+        "  proportion_threshold=threshold_for_seasonality # pipeline param (e.g. 0.6, meaning that to be considered seasonal, the n-month block should contain at least 60% of the annual rainfall)\n",
+        ")\n",
+        "\n",
+        "head(row_seasonality_dt, 5)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9d032593",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP added for data exploration\n",
+        "\n",
+        "filename <- paste0('GP_row_seasonality_dt', \"_frollsum\", '.parquet') # This is the \"original\" version. Will be overwritten if same selected for `compute_month_seasonality_NEW()`, else there will be 2 files with suffixes \"_frollsum\" and \"_calendar\" respectively\n",
+        "write_parquet(row_seasonality_dt, file.path(\"~/workspace/ad_hoc_analyses/rainfall_seasonality\", filename))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "86e550ac",
+      "metadata": {},
+      "source": [
+        "-------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0cc4acc9",
+      "metadata": {},
+      "source": [
+        "### ⭐ 1. (NEW) **Identify \"start\" month**\n",
+        "\n",
+        "> _Is this **month** a **start**?_  \n",
+        "\n",
+        "In `compute_month_seasonality_NEW()` can now choose alternative approach for **denominator**: \"calendar\" year OR \"frollsum\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ab840df4",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# ⭐ GP: new version of the function using different approach for **denominator** (rest remains the same)\n",
+        "# ⚠️ TO MOVE to \"snt_utils.r\" is approved ⚠️\n",
+        "\n",
+        "compute_month_seasonality_NEW <- function(input_dt, indicator, values_colname, vector_of_durations, \n",
+        "                                      admin_colname = 'ADM2_ID', year_colname = 'YEAR', month_colname = 'MONTH', \n",
+        "                                      proportion_threshold = 0.6, \n",
+        "                                      use_calendar_year_denominator = FALSE) {\n",
+        "  #' create forward-looking month blocks summing values based on the WHO month-block reasoning for seasonality computation - allows for different block sizes\n",
+        "  #' @param input_dt an input data table (or data frame)\n",
+        "  #' @param indicator a string to specify the type of indicator (case/rainfall/etc. - will be added to the output variable name)\n",
+        "  #' @param values_colname the indicator column, on which the computations are made\n",
+        "  #' @param vector_of_durations the vector with the number of months in a block (3/4/5)\n",
+        "  #' @param admin_colname the administrative units to group \n",
+        "  #' @param year_colname year grouping column\n",
+        "  #' @param month_colname month grouping column\n",
+        "  #' @param proportion_threshold the proportion of indicator which needs to occur in a block, to qualify for seasonality\n",
+        "  #' @param use_calendar_year_denominator Logical. If TRUE, uses the total accumulated rainfall of the current calendar year (Jan-Dec) as the denominator. If FALSE, uses the 12-month forward rolling sum.\n",
+        "  #' @return an output data table with the additional column\n",
+        "\n",
+        "  indicator <- toupper(indicator)\n",
+        "  dt <- copy(as.data.table(input_dt))\n",
+        "   \n",
+        "  # ensure correct order\n",
+        "  dt <- dt[order(get(admin_colname), get(year_colname), get(month_colname))]\n",
+        "   \n",
+        "  # ---------------------------------------------------------\n",
+        "  # DENOMINATOR CALCULATION\n",
+        "  # ---------------------------------------------------------\n",
+        "  if (use_calendar_year_denominator) {\n",
+        "    # Alternative Approach: Total accumulated rainfall for the current calendar year (Jan-Dec)\n",
+        "    # Group by Admin AND Year to get the annual sum\n",
+        "    denominator_colname <- paste(indicator, \"SUM_CALENDAR_YEAR\", sep = \"_\")\n",
+        "    \n",
+        "    dt[, (denominator_colname) := sum(get(values_colname), na.rm = TRUE), \n",
+        "       by = c(admin_colname, year_colname)]\n",
+        "       \n",
+        "  } else {\n",
+        "    # Original Approach: 12-month forward-looking sliding sum (left-aligned)\n",
+        "    denominator_colname <- paste(indicator, \"SUM\", 12, \"MTH\", \"FW\", sep = \"_\")\n",
+        "    \n",
+        "    dt[, (denominator_colname) := frollsum(get(values_colname),\n",
+        "                                           n = 12,\n",
+        "                                           align = \"left\",\n",
+        "                                           na.rm = TRUE),\n",
+        "       by = admin_colname]\n",
+        "  }\n",
+        "   \n",
+        "  # ---------------------------------------------------------\n",
+        "  # NUMERATOR & RATIO CALCULATIONS\n",
+        "  # ---------------------------------------------------------\n",
+        "  # numerators for each of the durations (forward-looking)\n",
+        "  for (n in vector_of_durations) {\n",
+        "    numerator_colname  <- paste(indicator, \"SUM\", n, \"MTH\", \"FW\", sep = \"_\")\n",
+        "    prop_name <- paste(indicator, n, \"MTH\", \"ROW\", \"PROP\", sep = \"_\")\n",
+        "    seasonality_colname <- paste(indicator, n, \"MTH\", \"ROW\", \"SEASONALITY\", sep = \"_\")\n",
+        "     \n",
+        "    # Calculate numerator: Rolling sum of next n months\n",
+        "    dt[, (numerator_colname) := frollsum(get(values_colname),\n",
+        "                                         n = n,\n",
+        "                                         align = \"left\",\n",
+        "                                         na.rm = TRUE),\n",
+        "       by = admin_colname]\n",
+        "     \n",
+        "    # Calculate Proportion: Numerator / Denominator (using the dynamically selected denominator)\n",
+        "    dt[, (prop_name) := \n",
+        "          # make NA's where it would be division by zero\n",
+        "          fifelse(get(denominator_colname) > 0, get(numerator_colname) / get(denominator_colname), NA_real_)]\n",
+        "     \n",
+        "    # Calculate Seasonality Flag\n",
+        "    dt[, (seasonality_colname) := as.integer(get(denominator_colname) > 0 &\n",
+        "                                             get(prop_name) >= proportion_threshold)]\n",
+        "  }\n",
+        "   \n",
+        "  # return the data\n",
+        "  dt[]\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "082d03b0",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# The seasonality per row (period-admin unit) -----------------------------\n",
+        "\n",
+        "row_seasonality_dt <- compute_month_seasonality_NEW(\n",
+        "  input_dt=imputed_dt, # The cleaned and valid rainfall data\n",
+        "  indicator=type_of_seasonality, # \"RAINFALL\" (legacy parameter name, we could simply spell it out now)\n",
+        "  values_colname=imputed_col, # \"MEAN_EST\" = mean rainfall (mm). \"_EST\" because it can be the original value or the imputed one, depending on the case\n",
+        "  vector_of_durations=possible_month_block_sizes, # pipeline param (e.g. 3, 4, 5 months)\n",
+        "  admin_colname=admin_id_col, # ADM2_ID (also could be hard-coded as it's always gonna be at AMD2 level ... )\n",
+        "  year_colname=year_col, # YEAR (also could be hard-coded as it's always gonna be the same col name across SNT toolbox ...)\n",
+        "  month_colname=month_col, # MONTH (also could be hard-coded as it's always gonna be the same col name across SNT toolbox ...)\n",
+        "  proportion_threshold=threshold_for_seasonality, # pipeline param (e.g. 0.6, meaning that to be considered seasonal, the n-month block should contain at least 60% of the annual rainfall)\n",
+        "  # ⭐ NEW\n",
+        "  use_calendar_year_denominator=USE_CALENDAR_YEAR_DENOMINATOR # Logical. If TRUE, uses the total accumulated rainfall of the current calendar year (Jan-Dec) as the denominator. If FALSE, uses the 12-month forward rolling sum.\n",
+        ")\n",
+        "\n",
+        "head(row_seasonality_dt, 5)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "90c042ef",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP added for data exploration\n",
+        "\n",
+        "filename <- paste0('GP_row_seasonality_dt', SUFFIX, '.parquet') \n",
+        "write_parquet(row_seasonality_dt, file.path(\"~/workspace/ad_hoc_analyses/rainfall_seasonality\", filename))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a9520aff",
+      "metadata": {},
+      "source": [
+        "--------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "914c3a26",
+      "metadata": {},
+      "source": [
+        "### 2. **Classify an `ADM2` as \"Seasonal\" or \"Non-seasonal\"**\n",
+        "\n",
+        "> _Is the **district** (ADM2) seasonal?_\n",
+        "\n",
+        "(\"Admin-Level Seasonality\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c780d40f",
+      "metadata": {},
+      "source": [
+        "**Logic**:\n",
+        "* If a specific month (e.g., January) is flagged as a \"start\" in > ***Y%*** of the years, the **`ADM2` is seasonal**.\n",
+        "    * Namely: \n",
+        "        * group by `ADM2_ID` and `MONTH` then\n",
+        "        * count how many `RAINFALL_{n}_MTH_ROW_SEASONALITY` == 1 (sum of success). Basically: **how many times (`YEAR`s) a given `MONTH` was a \"start\"**\n",
+        "        * calculate the proportion of years and compares it to the `proportion_seasonal_years_threshold` (***Y%***, e.g., 70%)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a666e2c3",
+      "metadata": {},
+      "source": [
+        "The **output** of `process_seasonality()` is a dt with the following cols:\n",
+        "* `ADM2_ID`\n",
+        "* `PROP_SEASONAL_RAINFALL_{n}_MTH`: the **consistency** (frequency) of a specific `MONTH` being the ***start*** of the rainy season (for a given ADM2). \n",
+        "    * Basically, _how often (proportion of years) was this month the start of a {n}-months seasonal block?_\n",
+        "* `SEASONALITY_RAINFALL_{n}_MTH`: a **binary flag (1 or 0)** indicating whether the `ADM2` is **considered seasonal** for a {n}-month block duration\n",
+        "    * `1` (Seasonal): **The `ADM2` has at least one month in the year that _consistently_** (e.g., in >70% of years) **marks the start of a \"rain season\"**. Where \"rain season\" is a {n}-month block containing the majority (e.g., > 60%) of the annual rainfall.\n",
+        "    * `0` (Not Seasonal): No month in the year meets the consistency criteria for that {n}-month block."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5c792fc4",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# The seasonality per admin unit, irrespective of year ----------------------\n",
+        "\n",
+        "seasonality_source_dt <- process_seasonality(\n",
+        "  input_dt=row_seasonality_dt, # Output of the previous step (\"is this month a start?\")\n",
+        "  indicator=type_of_seasonality, # \"RAINFALL\" (legacy parameter name, we could simply spell it out now)\n",
+        "  vector_of_durations=possible_month_block_sizes, # pipeline param (e.g. 3, 4, 5 months)\n",
+        "  admin_colname=admin_id_col, # ADM2_ID (also could be hard-coded as it's always gonna be at AMD2 level ... )\n",
+        "  year_colname=year_col, # YEAR (also could be hard-coded as it's always gonna be the same col name across SNT toolbox ...)\n",
+        "  month_colname=month_col, # MONTH (also could be hard-coded as it's always gonna be the same col name across SNT toolbox ...)\n",
+        "  proportion_seasonal_years_threshold=threshold_proportion_seasonal_years # pipeline param (e.g. 0.5, meaning that to be considered seasonal, at least 50% of the years should have the same seasonal pattern\n",
+        ")\n",
+        "\n",
+        "head(seasonality_source_dt, 5)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ff71f92f",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP: export the seasonality_source_dt as well for data exploration and debugging purposes\n",
+        "filename <- paste0('GP_seasonality_source_dt', SUFFIX, '.parquet')\n",
+        "write_parquet(seasonality_source_dt, file.path(\"~/workspace/ad_hoc_analyses/rainfall_seasonality\", filename))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "206bd4d9",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP: keep only relevant cols: `ADM2_ID`, `SEASONALITY_RAINFALL_{n}_MTH`\n",
+        "#  (e.g., SEASONALITY_RAINFALL_3_MTH, SEASONALITY_RAINFALL_4_MTH, SEASONALITY_RAINFALL_5_MTH, ...)\n",
+        "check_pattern_seasonality <- paste0(\"^SEASONALITY_RAINFALL\", \"_[0-9]+_MTH$\")\n",
+        "seasonality_source_dt <- seasonality_source_dt %>%\n",
+        "    select(all_of(admin_id_col), matches(check_pattern_seasonality))\n",
+        "\n",
+        "head(seasonality_source_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d9f8270f-7283-4630-b9ba-62366b1c3e62",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "source": [
+        "#### Result file"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "477fb459-0f98-4a32-96ab-f10b4395495f",
+      "metadata": {},
+      "source": [
+        "##### Make \"long\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "50ba68f5-e9a9-4144-99dc-de8cc44770e9",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "seasonality_long_dt <- melt(\n",
+        "  seasonality_source_dt,\n",
+        "  id.vars = grep(check_pattern_seasonality, names(seasonality_source_dt), value = TRUE, invert = TRUE), # all cols which don't follow the pattern\n",
+        "  variable.name = 'MONTH_BLOCK_SIZE',\n",
+        "  value.name =seasonality_col\n",
+        "  )\n",
+        "\n",
+        "head(seasonality_long_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b2a400d4-a545-40ab-9204-b6b2e69ea499",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "seasonality_long_dt[, MONTH_BLOCK_SIZE := possible_month_block_sizes[match(MONTH_BLOCK_SIZE, grep(check_pattern_seasonality, names(seasonality_source_dt), value = TRUE))]]\n",
+        "\n",
+        "# add remaining admin unit columns and save the final results\n",
+        "admin_seasonality_long_dt <- merge.data.table(admin_data, seasonality_long_dt, by = c(admin_id_col), all = TRUE)\n",
+        "\n",
+        "head(admin_seasonality_long_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7a7926d5-d4e7-4707-85b8-7020c3738be3",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# order the columns\n",
+        "specific_cols <- setdiff(names(admin_seasonality_long_dt), names(admin_data)) # last columns\n",
+        "admin_seasonality_long_dt <- admin_seasonality_long_dt[, .SD, .SDcols = c(common_cols, specific_cols)]\n",
+        "\n",
+        "head(admin_seasonality_long_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b3ba3dd1",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP: Export \n",
+        "filename <- paste0('GP_admin_seasonality_long_dt', SUFFIX, '.parquet')\n",
+        "write_parquet(seasonality_source_dt, file.path(\"~/workspace/ad_hoc_analyses/rainfall_seasonality\", filename))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5949cc94",
+      "metadata": {},
+      "source": [
+        "### 3. **Determine season _duration_**\n",
+        "> _How long is the rain season?_\n",
+        "\n",
+        "Idenitfy length (number of months) of the rain season.\n",
+        "\n",
+        "**Logic**: If an `ADM2` qualifies for multiple block sizes (e.g., 3, 4, and 5 months), pick the ***shortest*** period (minimum)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0eea7fca",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-block alert-warning\">\n",
+        "Idea: <br>\n",
+        "Here we should try to add the info of the <b>proportion of yearly rainfall</b> that falls in the {n}-month block!\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e3c9c463",
+      "metadata": {},
+      "source": [
+        "The **output** of `compute_min_seasonality_block()` is a dt with the following cols:\n",
+        "* `ADM2_ID`\n",
+        "* `SEASONALITY_RAINFALL_{n}_MTH`: binary flag (1 or 0) for `ADM2` **seasonality**. Produced in previous step (2) and retained here\n",
+        "* `SEASONAL_BLOCK_DURATION_RAINFALL`: minimum duration of rainfall season"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "36d1f9cb-75b6-4f6a-a18c-b34eb233b8d2",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": []
+      },
+      "source": [
+        "##### (Transform to wide format)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e71259c9-29a6-452f-8949-74adb0e62c1c",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "seasonality_wide_dt <- compute_min_seasonality_block(\n",
+        "    input_dt=seasonality_source_dt, # Output of the previous step (\"is ADM2 seasonal for a given {n}-months block?\"), then keep only the relevant cols\n",
+        "    seasonality_column_pattern=check_pattern_seasonality, # '^SEASONALITY_RAINFALL_[0-9]+_MTH$'\n",
+        "    vector_of_possible_month_block_sizes=possible_month_block_sizes, # pipeline param (e.g. 3, 4, 5 months)\n",
+        "    seasonal_blocksize_colname=season_duration_col, # output colname: 'SEASONAL_BLOCK_DURATION_RAINFALL'\n",
+        "    valid_value = 1 # value indicating seasonality\n",
+        ")\n",
+        "\n",
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "49c0c796",
+      "metadata": {},
+      "source": [
+        "-------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "31a179f4",
+      "metadata": {},
+      "source": [
+        "### 3. (Simplified) **Determine season _duration_**\n",
+        "\n",
+        "> _How long is the rain season?_\n",
+        "\n",
+        "This does exactly the same as `compute_min_seasonality_block()`, but it's more accessible (readable) as it does not require importing a dedicated function from snt_utils.r"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bf2fa6f6",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "head(admin_seasonality_long_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "061202a9",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# GP simplified code: \n",
+        "# same as `compute_min_seasonality_block() but without function call (seems unnecessarly complicated)\n",
+        "\n",
+        "seasonality_wide_GP <- admin_seasonality_long_dt |>\n",
+        "filter(SEASONALITY_RAINFALL == 1) |>\n",
+        "group_by(ADM2_ID) |>\n",
+        "summarise(\n",
+        "    SEASONAL_BLOCK_DURATION_RAINFALL = min(MONTH_BLOCK_SIZE, na.rm = TRUE)\n",
+        ") \n",
+        "\n",
+        "head(seasonality_wide_GP)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d4963ec5",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Compare the two versions of the seasonality block duration \n",
+        "# (the one computed with the function and the one computed with the simplified code) \n",
+        "# to make sure they are the same\n",
+        "\n",
+        "original <- seasonality_wide_dt |> select(ADM2_ID, SEASONAL_BLOCK_DURATION_RAINFALL) |> arrange(ADM2_ID) \n",
+        "simplified <- seasonality_wide_GP |> select(ADM2_ID, SEASONAL_BLOCK_DURATION_RAINFALL) |> arrange(ADM2_ID)\n",
+        "\n",
+        "# Check if any FALSE values in the comparison of the two dataframes\n",
+        "any(original$SEASONAL_BLOCK_DURATION_RAINFALL != simplified$SEASONAL_BLOCK_DURATION_RAINFALL)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "268de8a4",
+      "metadata": {},
+      "source": [
+        "--------------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c3af96c9",
+      "metadata": {},
+      "source": [
+        "### 🤌🏼 What is this for??"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8d99b43e",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Create a new, overall column 'SEASONALITY_' based on the values of columns in 'check_pattern_seasonality'\n",
+        "seasonality_pattern_cols <- grep(check_pattern_seasonality, names(seasonality_wide_dt), value = TRUE)\n",
+        "if (length(seasonality_pattern_cols) > 0L) {\n",
+        "  seasonality_wide_dt <- seasonality_wide_dt[, (seasonality_col) := ifelse(rowSums(.SD == 1, na.rm = TRUE) > 0, 1L, 0L), .SDcols = seasonality_pattern_cols]\n",
+        "  seasonality_wide_dt <- seasonality_wide_dt[, (seasonality_pattern_cols) := NULL]\n",
+        "} else {\n",
+        "  seasonality_wide_dt[, (seasonality_col) := NA_integer_]\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "70407952",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "916e3e4f",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Compute RAIN_PROPORTION: proportion of rainfall in the seasonal block vs ANNUAL total\n",
+        "# Only for seasonal admin units (SEASONALITY_RAINFALL = 1)\n",
+        "\n",
+        "# Step 1: Compute annual totals per admin-year from imputed data\n",
+        "annual_totals_dt <- imputed_dt[, .(ANNUAL_TOTAL = sum(get(imputed_col), na.rm = TRUE)), by = c(admin_id_col, year_col)]\n",
+        "\n",
+        "head(annual_totals_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "332f357d",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Step 2: Function to compute proportion = max block sum / annual total\n",
+        "compute_rain_proportion <- function(admin_id, block_duration, row_data, annual_data, admin_col, year_column) {\n",
+        "  if (is.na(block_duration) || is.infinite(block_duration)) return(NA_real_)\n",
+        "  \n",
+        "  # Column with block sum (N-month forward-looking sum)\n",
+        "  sum_col <- paste('RAINFALL_SUM', block_duration, 'MTH_FW', sep = '_')\n",
+        "  if (!sum_col %in% names(row_data)) return(NA_real_)\n",
+        "  \n",
+        "  admin_row_data <- row_data[get(admin_col) == admin_id]\n",
+        "  admin_annual_data <- annual_data[get(admin_col) == admin_id]\n",
+        "  if (nrow(admin_row_data) == 0 || nrow(admin_annual_data) == 0) return(NA_real_)\n",
+        "  \n",
+        "  # For each year, get max block sum (only if there are non-NA values)\n",
+        "  yearly_max_block <- admin_row_data[\n",
+        "    !is.na(get(sum_col)),\n",
+        "    .(max_block_sum = if (.N > 0L) max(get(sum_col), na.rm = TRUE) else NA_real_),\n",
+        "    by = year_column\n",
+        "  ]\n",
+        "  \n",
+        "  # Remove rows with NA or -Inf (from max when all values were NA)\n",
+        "  yearly_max_block <- yearly_max_block[is.finite(max_block_sum)]\n",
+        "  if (nrow(yearly_max_block) == 0) return(NA_real_)\n",
+        "  \n",
+        "  # Merge with annual totals\n",
+        "  merged <- merge(yearly_max_block, admin_annual_data, by = year_column)\n",
+        "  merged <- merged[ANNUAL_TOTAL > 0]\n",
+        "  if (nrow(merged) == 0) return(NA_real_)\n",
+        "  \n",
+        "  # Proportion = block sum / annual total, then average across years\n",
+        "  merged[, prop := max_block_sum / ANNUAL_TOTAL]\n",
+        "  return(mean(merged$prop, na.rm = TRUE))\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5e2d8225",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "seasonality_wide_dt[, (rain_proportion_col) := mapply(\n",
+        "  compute_rain_proportion,\n",
+        "  admin_id = get(admin_id_col), \n",
+        "  block_duration = get(season_duration_col), # value of col `SEASONAL_BLOCK_DURATION_RAINFALL` (e.g., 3, 4, 5 (months))\n",
+        "  MoreArgs = list(\n",
+        "    row_data = row_seasonality_dt, # output of step 1 (\"is this month a start of the seasonal block?\")\n",
+        "    annual_data = annual_totals_dt, # output of cell just above this one (annual rainfall totals per admin-year)\n",
+        "    admin_col = admin_id_col, # 'ADM2_ID'\n",
+        "    year_column = year_col # 'YEAR'\n",
+        "    )\n",
+        ")]\n",
+        "\n",
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "55fc0b08",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "seasonality_wide_dt |> filter(ADM2_ID == 'AXYBpkHRL1P') "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1391729a",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Set RAIN_PROPORTION to NA for non-seasonal admin units\n",
+        "seasonality_wide_dt[get(seasonality_col) == 0 | is.na(get(seasonality_col)), (rain_proportion_col) := NA_real_]\n",
+        "\n",
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "112c8def",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8a99894e",
+      "metadata": {},
+      "source": [
+        "### 4. **Determine season _onset_**\n",
+        "\n",
+        "> _**When** does the rain season **start**?_\n",
+        "\n",
+        "**Logic**: Find the **most frequent** start `MONTH` (Mode)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b7127c4c",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# # Compute SEASONAL_BLOCK_START_MONTH: first month of the seasonal block\n",
+        "# # Only for seasonal admin units (SEASONALITY_RAINFALL = 1)\n",
+        "\n",
+        "# # Function to find the most frequent starting month for a given admin unit and block duration\n",
+        "# compute_start_month <- function(admin_id, block_duration, row_data, admin_col, year_column, month_column) {\n",
+        "#   if (is.na(block_duration) || is.infinite(block_duration)) return(NA_integer_)\n",
+        "  \n",
+        "#   # Column with row-level seasonality indicator for this block duration\n",
+        "#   seasonality_row_col <- paste('RAINFALL', block_duration, 'MTH_ROW_SEASONALITY', sep = '_')\n",
+        "#   if (!seasonality_row_col %in% names(row_data)) return(NA_integer_)\n",
+        "  \n",
+        "#   admin_row_data <- row_data[get(admin_col) == admin_id]\n",
+        "#   if (nrow(admin_row_data) == 0) return(NA_integer_)\n",
+        "  \n",
+        "#   # Filter rows where seasonality = 1 (this month is the start of a seasonal block)\n",
+        "#   seasonal_months <- admin_row_data[get(seasonality_row_col) == 1, get(month_column)]\n",
+        "  \n",
+        "#   if (length(seasonal_months) == 0) return(NA_integer_)\n",
+        "  \n",
+        "#   # Find the most frequent month (mode)\n",
+        "#   month_counts <- table(seasonal_months)\n",
+        "#   most_frequent_month <- as.integer(names(month_counts)[which.max(month_counts)])\n",
+        "  \n",
+        "#   return(most_frequent_month)\n",
+        "# }\n",
+        "\n",
+        "# seasonality_wide_dt[, (season_start_month_col) := mapply(\n",
+        "#   compute_start_month,\n",
+        "#   admin_id = get(admin_id_col), # 'ADM2_ID'\n",
+        "#   block_duration = get(season_duration_col), # `SEASONAL_BLOCK_DURATION_RAINFALL` (can be hard-coded!)\n",
+        "#   MoreArgs = list(\n",
+        "#     row_data = row_seasonality_dt, # output of step 1 (\"is this month a start?\")\n",
+        "#     admin_col = admin_id_col, # 'ADM2_ID'\n",
+        "#     year_column = year_col,   # 'YEAR'\n",
+        "#     month_column = month_col  # 'MONTH'\n",
+        "#     )\n",
+        "# )]\n",
+        "\n",
+        "# head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6a5daa60",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# # Set SEASONAL_BLOCK_START_MONTH to NA for non-seasonal admin units\n",
+        "# seasonality_wide_dt[get(seasonality_col) == 0 | is.na(get(seasonality_col)), (season_start_month_col) := NA_integer_]\n",
+        "\n",
+        "# head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ea8b6ccd",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "source": [
+        "----------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f77c8f8b",
+      "metadata": {},
+      "source": [
+        "### 4. (Commented) **Determine season _onset_**\n",
+        "\n",
+        "> _**When** does the rain season **start**?_\n",
+        "\n",
+        "**Logic**: Find the **most frequent** start `MONTH` (Mode)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6bbf5fe2",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Compute SEASONAL_BLOCK_START_MONTH: first month of the seasonal block\n",
+        "# Only for seasonal admin units (SEASONALITY_RAINFALL = 1)\n",
+        "\n",
+        "# Function to find the most frequent starting month for a given admin unit and block duration\n",
+        "compute_start_month <- function(admin_id, block_duration, row_data, admin_col, year_column, month_column) {\n",
+        "  \n",
+        "  # VALIDATION: Check if the block duration is valid (not NA or Infinite). \n",
+        "  # If invalid, return an integer NA immediately.\n",
+        "  if (is.na(block_duration) || is.infinite(block_duration)) return(NA_integer_)\n",
+        "  \n",
+        "  # DYNAMIC COLUMN GENERATION: Construct the specific column name based on the block duration.\n",
+        "  # Example: If block_duration is 3, this looks for 'RAINFALL_3_MTH_ROW_SEASONALITY'.\n",
+        "  seasonality_row_col <- paste('RAINFALL', block_duration, 'MTH_ROW_SEASONALITY', sep = '_')\n",
+        "  \n",
+        "  # SAFETY CHECK: Ensure the constructed column name actually exists in the provided dataset.\n",
+        "  if (!seasonality_row_col %in% names(row_data)) return(NA_integer_)\n",
+        "  \n",
+        "  # SUBSET DATA: Filter the large dataset 'row_data' to get only rows matching the current 'admin_id'.\n",
+        "  # IMPROVEMENT: This is a performance bottleneck. Filtering the full 'row_data' inside the function \n",
+        "  # for every single row of 'seasonality_wide_dt' (via mapply) is very slow. \n",
+        "  # A data.table join or aggregation (using `by = admin_id`) would be significantly faster.\n",
+        "  admin_row_data <- row_data[get(admin_col) == admin_id]\n",
+        "  \n",
+        "  # Check if we actually found data for this admin unit.\n",
+        "  if (nrow(admin_row_data) == 0) return(NA_integer_)\n",
+        "  \n",
+        "  # FILTER FOR START MONTHS: Look at the rows for this admin. \n",
+        "  # Keep only the rows where the seasonality flag is 1 (meaning a season starts there).\n",
+        "  # Extract the 'month' value from these rows.\n",
+        "  seasonal_months <- admin_row_data[get(seasonality_row_col) == 1, get(month_column)]\n",
+        "  \n",
+        "  # Check if any seasonal start months were found.\n",
+        "  if (length(seasonal_months) == 0) return(NA_integer_)\n",
+        "  \n",
+        "  # FIND MODE (Most Frequent Month):\n",
+        "  # 1. Create a frequency table of the start months found above.\n",
+        "  month_counts <- table(seasonal_months)\n",
+        "  \n",
+        "  # 2. Identify the month with the highest count.\n",
+        "  # NOTE: 'which.max' picks the first maximum in case of a tie. If month 1 and month 5 \n",
+        "  # appear equally often, the code will pick the one that appears first in the table.\n",
+        "  most_frequent_month <- as.integer(names(month_counts)[which.max(month_counts)])\n",
+        "  \n",
+        "  return(most_frequent_month)\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "eb63bc99",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# EXECUTION: Apply the function to every row in 'seasonality_wide_dt'.\n",
+        "# This creates a new column (defined by 'season_start_month_col') with the results.\n",
+        "seasonality_wide_dt[, (season_start_month_col) := mapply(\n",
+        "  compute_start_month,\n",
+        "  admin_id = get(admin_id_col), # 'ADM2_ID'\n",
+        "  block_duration = get(season_duration_col), # `SEASONAL_BLOCK_DURATION_RAINFALL` (can be hard-coded!)\n",
+        "  MoreArgs = list(\n",
+        "    row_data = row_seasonality_dt, # output of step 1 (\"is this month a start?\")\n",
+        "    admin_col = admin_id_col, # 'ADM2_ID'\n",
+        "    year_column = year_col,   # 'YEAR'\n",
+        "    month_column = month_col  # 'MONTH'\n",
+        "    )\n",
+        ")]\n",
+        "\n",
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e0931fed",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Set SEASONAL_BLOCK_START_MONTH to NA for non-seasonal admin units\n",
+        "seasonality_wide_dt[get(seasonality_col) == 0 | is.na(get(seasonality_col)), (season_start_month_col) := NA_integer_]\n",
+        "\n",
+        "head(seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "eae25616",
+      "metadata": {},
+      "source": [
+        "------------"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9adbdab1",
+      "metadata": {},
+      "source": [
+        "## Add ADM cols before exporting"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c5ea18ef-1148-432d-a954-b9c6b4a06afc",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# add remaining admin unit columns and save the final results\n",
+        "admin_seasonality_wide_dt <- merge.data.table(admin_data, seasonality_wide_dt, by = c(admin_id_col), all = TRUE)\n",
+        "admin_seasonality_wide_dt <- admin_seasonality_wide_dt[, .SD, .SDcols = c(common_cols, seasonality_cols)]\n",
+        "# head(admin_seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "39b9046d",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Export admin_data as csv\n",
+        "fwrite(admin_data, file.path(\"~/workspace/ad_hoc_analyses/rainfall_seasonality\", \"admin_data.csv\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d1daff9b",
+      "metadata": {
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "head(admin_seasonality_wide_dt)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a2f1a373-4b34-42db-b591-b25c7050dee6",
+      "metadata": {},
+      "source": [
+        "**Save output**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b9b4993b",
+      "metadata": {},
+      "source": [
+        "`admin_seasonality_wide_dt`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ded1e86d-f4c5-4fdb-a6ba-611d5c7f4aed",
+      "metadata": {
+        "editable": true,
+        "slideshow": {
+          "slide_type": ""
+        },
+        "tags": [],
+        "vscode": {
+          "languageId": "r"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Create the filename\n",
+        "file_stem <- paste(COUNTRY_CODE, type_of_seasonality, 'seasonality', sep = '_') # these are the filenames which will be saved in the dataset (if change, will not be available to reporting nb)\n",
+        "# file_stem <- paste0(COUNTRY_CODE, \"_\", type_of_seasonality, \"_seasonality\", SUFFIX) # \n",
+        "filename_csv = glue(\"{file_stem}.csv\")\n",
+        "filename_parquet = glue(\"{file_stem}.parquet\")\n",
+        "fwrite(admin_seasonality_wide_dt, file.path(OUTPUT_DATA_PATH, filename_csv))\n",
+        "write_parquet(admin_seasonality_wide_dt, file.path(OUTPUT_DATA_PATH, filename_parquet))\n",
+        "log_msg(paste0(\"Rainfall seasonality results saved in folder \", OUTPUT_DATA_PATH))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "R",
+      "language": "R",
+      "name": "ir"
+    },
+    "language_info": {
+      "codemirror_mode": "r",
+      "file_extension": ".r",
+      "mimetype": "text/x-r-source",
+      "name": "R",
+      "pygments_lexer": "r",
+      "version": "4.4.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Changed logic of `select_population_column()` so that it fails if the column with the chosen selected population disaggregation is missing from population data.
If no disaggregation is selected, then just use regular population data (column `POPULATION`).

Note:  `select_population_column()` only evaluates pop data if the disaggregated indicators were found in routine data (previous step)