### PR TITLE
fix(dhis2 formatting): duplicated rows introduced by merging of dhis2…

### DIFF
--- a/pipelines/snt_dhis2_formatting/code/snt_dhis2_formatting_routine.ipynb
+++ b/pipelines/snt_dhis2_formatting/code/snt_dhis2_formatting_routine.ipynb
@@ -90,7 +90,7 @@
     "\n",
     "# Select only metadata (reduce the size of the dataframe)\n",
     "administrative_cols <- colnames(dhis2_data)[grepl(\"LEVEL_\", colnames(dhis2_data))]\n",
-    "dhis2_metadata <- dhis2_data[ , c(\"OU\", \"DX_NAME\", administrative_cols)] # Metadata\n",
+    "dhis2_metadata <- dhis2_data[ , c(\"OU\", administrative_cols)]\n",
     "dhis2_metadata <- distinct(dhis2_metadata)\n",
     "print(glue(\"Data element names: \\n {paste(unique(dhis2_metadata$DX_NAME), collapse=',\\n ')}\"))\n",
     "\n",
@@ -103,7 +103,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eea23e94-1118-43c7-9ee4-73aa8ac2adb2",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Max admin columns available (matchin ou)\n",
@@ -167,7 +171,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7ff54ba9-888b-4301-aa0a-a813e5259b95",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "dhis_indicator_definitions <- config_json$DHIS2_DATA$DHIS2_INDICATOR_DEFINITIONS\n",
@@ -180,7 +188,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "89f49b04-245e-4b24-bb38-25800a05bd2d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Select the list of valid indicators from the definitions: \n",
@@ -204,7 +216,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "16ec64ae-9537-470c-84bb-0e190e799117",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# build SNT indicators \n",


### PR DESCRIPTION
See: https://bluesquare.atlassian.net/browse/SNT25-635

Duplicated rows introduced in routine data due to DX_NAME in  `dhis2_metadata <- dhis2_data[ , c("OU", "DX_NAME", administrative_cols)]` which adds to a line for each unique `DX_NAME` of each `OU` ... 

Fix: is a simple change this one line of code.

I'm surprised this duplication was not creating any issue downstream ... 🤔 in any case it should make the formatted routine data file smaller.