### PR TITLE
SNT25-618_incidence-report

### DIFF
--- a/pipelines/snt_dhis2_incidence/reporting/snt_dhis2_incidence_report.ipynb
+++ b/pipelines/snt_dhis2_incidence/reporting/snt_dhis2_incidence_report.ipynb
@@ -1,6 +1,52 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "078a388a",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# GP (2026-08-21) stuff done in SNT25-618\n",
+    "# - Change issue as not really duplicated ... https://bluesquare.atlassian.net/browse/SNT25-618 is SMALLER than the older one (JUST NOT BREAK AND FIGS SHOW UP OK)\n",
+    "# - Code replaced by utils funs: a few more to be adde, but that requiers more work on SNT_utils.R (separate Jira)\n",
+    "# - Cleaned up text and translated to French\n",
+    "# - Updated a breaking hardcoded parameter `USE_ADJUSTED_POPULATION` -> `USE_TRANSFORMED_POPULATION`\n",
+    "\n",
+    "# Remains ToDo:\n",
+    "# - [in CODE nb!] Adj3 should be NA if Adj2 is NA ... ! \n",
+    "#   -> see: https://bluesquare.atlassian.net/browse/SNT25-646\n",
+    "# - 🚨 Need to handle cases where `FLAG_*` is (all) `NA`s ... !!\n",
+    "#       (this should be fixed by above point)\n",
+    "# - Plots of RR should be MOVED to the RR pipeline report (not incidence)!!!\n",
+    "#   (these were included here because incidence consumes RR and therefore RR affects results,\n",
+    "#   but the RR plots are not really part of incidence reporting)\n",
+    "# - Scatter plots (coherence) should be made with 📦{scattermore} (rasterized) for lighter figures"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbccd353",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Code tested in:\n",
+    "# - \"SNT Testing\" (COD)\n",
+    "# - \"NER SNT Process\" (NER)\n",
+    "# - \"CMR SNT Process\" (CMR)\n",
+    "# - \"BDI SNT Process\" (BDI)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9f017694-ec13-4584-80cb-c1c529863ec1",
    "metadata": {},
@@ -19,25 +65,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5b30ae1-805f-444f-a34c-049b590e04b7",
-   "metadata": {},
+   "id": "51e328f8",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# Set SNT Paths\n",
     "SNT_ROOT_PATH  <- \"~/workspace\"\n",
     "CODE_PATH      <- file.path(SNT_ROOT_PATH, \"code\")\n",
     "CONFIG_PATH    <- file.path(SNT_ROOT_PATH, \"configuration\")\n",
-    "# DATA_PATH <- file.path(SNT_ROOT_PATH, 'data', 'dhis2')\n",
-    "DATA_PATH <- file.path(SNT_ROOT_PATH, 'data', 'dhis2', 'incidence') # store the output of the pipeline (only final results)\n",
-    "INTERMEDIATE_DATA_PATH <- file.path(DATA_PATH, \"intermediate_results\") # intermediate results for reporting nb or else, NOT for OH Dataset!\n",
-    "FIGURES_PATH <- file.path(SNT_ROOT_PATH, \"pipelines/snt_dhis2_incidence/reporting/outputs/figures\")\n",
+    "DATA_PATH <- file.path(SNT_ROOT_PATH, 'data', 'dhis2', 'incidence') # output of the pipeline (only final results)\n",
     "\n",
-    "# load util functions\n",
+    "INTERMEDIATE_DATA_PATH <- file.path(DATA_PATH, \"intermediate_results\") # for reporting nb or else, NOT for OH Dataset!\n",
+    "\n",
+    "REPORTING_NB_PATH <- file.path(SNT_ROOT_PATH, \"pipelines/snt_dhis2_incidence/reporting\")\n",
+    "FIGURES_PATH <- file.path(REPORTING_NB_PATH, \"outputs\", \"figures\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5b30ae1-805f-444f-a34c-049b590e04b7",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
     "source(file.path(CODE_PATH, \"snt_utils.r\"))\n",
-    "# Load palettes\n",
-    "source(file.path(CODE_PATH, \"snt_palettes.r\"))\n",
-    "\n",
-    "# List required packages \n",
+    "source(file.path(CODE_PATH, \"snt_palettes.r\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb47123",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
     "required_packages <- c(\n",
     "    \"dplyr\",\n",
     "    \"tidyr\",\n",
@@ -49,25 +121,52 @@
     "    \"reticulate\" \n",
     "    )\n",
     "\n",
-    "# Execute function\n",
     "install_and_load(required_packages)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d10d93d8",
-   "metadata": {},
+   "id": "38aa6723",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# Set environment to load openhexa.sdk from the right environment\n",
-    "Sys.setenv(RETICULATE_PYTHON = \"/opt/conda/bin/python\")\n",
-    "reticulate::py_config()$python\n",
-    "openhexa <- import(\"openhexa.sdk\")\n",
+    "# Create output directories if they don't exist (needs utils)\n",
+    "safe_create_dir(FIGURES_PATH) |> suppressMessages()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d10d93d8",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ⚠️🧹 GP: Move this function to ./code/snt_utils.r !\n",
+    "# (do as separate branch/task, see https://bluesquare.atlassian.net/browse/SNT25-591 )\n",
+    "init_openhexa_env <- function(\n",
+    "  # In nb, run as `openhexa <- init_openhexa_env()`\n",
+    "  python_path = \"/opt/conda/bin/python\",\n",
+    "  proj_lib = \"/opt/conda/share/proj\",\n",
+    "  gdal_data = \"/opt/conda/share/gdal\"\n",
+    ") {\n",
+    "  Sys.setenv(PROJ_LIB = proj_lib)\n",
+    "  Sys.setenv(GDAL_DATA = gdal_data)\n",
+    "  Sys.setenv(RETICULATE_PYTHON = python_path)\n",
+    "  reticulate::py_config()$python\n",
     "\n",
-    "# Required environment for the sf packages\n",
-    "Sys.setenv(PROJ_LIB = \"/opt/conda/share/proj\")\n",
-    "Sys.setenv(GDAL_DATA = \"/opt/conda/share/gdal\")"
+    "  return(reticulate::import(\"openhexa.sdk\"))\n",
+    "}\n",
+    "\n",
+    "openhexa <- init_openhexa_env()"
    ]
   },
   {
@@ -82,23 +181,25 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cb52fb2f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# Load SNT config\n",
-    "config_json <- tryCatch({ jsonlite::fromJSON(file.path(CONFIG_PATH, \"SNT_config.json\"))},\n",
-    "    error = function(e) {\n",
-    "        msg <- paste0(\"Error while loading configuration\", conditionMessage(e))  \n",
-    "        cat(msg)   \n",
-    "        stop(msg) \n",
-    "    })"
+    "config_json <- load_snt_config(config_path = CONFIG_PATH)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "5ef5b67d-f94c-40db-93ff-c5fdbdee134f",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Configuration variables\n",
@@ -125,9 +226,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6e406d8e",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
+    "# ⚠️ GP (2026-08-20): \n",
+    "# - Use utils fun to import \n",
+    "# - Consider removing dependency on \"SNT_metadata.json\" ... !\n",
+    "\n",
     "# Load SNT metadata\n",
     "metadata_json <- tryCatch({ jsonlite::fromJSON(file.path(CONFIG_PATH, \"SNT_metadata.json\")) },\n",
     "    error = function(e) {\n",
@@ -143,12 +252,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "04c6cab4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Handle situation in which metadata is not correctly loaded (for example if the specific node is missing in the json file)\n",
     "if (is.null(metadata_json$INCIDENCE_CRUDE$SCALE)) {\n",
-    "    log_msg(\"Warning: Incidence (crude) scale break values cannot be loaded from SNT_metadata.json because the node $INCIDENCE_CRUDE$SCALE is missing.\", \"warning\")\n",
+    "    log_msg(\"Info: Incidence (crude) scale break values cannot be loaded from SNT_metadata.json because the node $INCIDENCE_CRUDE$SCALE is missing.\")\n",
     "} else {\n",
     "    break_vals <- jsonlite::fromJSON(metadata_json$INCIDENCE_CRUDE$SCALE)\n",
     "    log_msg(paste0(\"Incidence (crude) scale break values loaded from SNT_metadata.json : \", paste(break_vals, collapse = \", \")))\n",
@@ -167,7 +280,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3916fbc6",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "DATASET_DHIS2 <- config_json$SNT_DATASET_IDENTIFIERS$DHIS2_DATASET_FORMATTED\n",
@@ -179,42 +296,31 @@
    "id": "0ddca5f6",
    "metadata": {},
    "source": [
-    "#### 2.0. Parameters: `parameters_json`\n",
-    "This is how we keep track of parameters choices. File stored in OH Dataset (same as main output).\n",
-    "\n",
-    "**Replaces the papermill-injected parameters which used to be in the first cell!**"
+    "#### 2.0. Parameters: `parameters_json`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f7d1a18",
-   "metadata": {},
+   "id": "3420e2b8",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# This is output of the main code notebook! => DATASET_INCIDENCE\n",
-    "parameters <- tryCatch({ get_latest_dataset_file_in_memory(DATASET_INCIDENCE, paste0(COUNTRY_CODE, \"_parameters.json\")) }, \n",
-    "                  error = function(e) {\n",
-    "                      msg <- paste(\"Error while loading DHIS2 Shapes data for: \" , COUNTRY_CODE, conditionMessage(e))\n",
-    "                      cat(msg)\n",
-    "                      stop(msg)\n",
-    "                      })\n",
+    "parameters <- load_country_file_from_dataset(\n",
+    "    dataset_id = DATASET_INCIDENCE, \n",
+    "    country_code = COUNTRY_CODE, \n",
+    "    suffix = \"_parameters.json\" \n",
+    "    )\n",
     "\n",
+    "# Dynamically assign each parameter as a variable named after its key\n",
+    "list2env(parameters, envir = environment())\n",
+    "\n",
+    "# Display values in report (just to check)\n",
     "glimpse(parameters)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5b1bb741",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "N1_METHOD <- parameters$N1_METHOD\n",
-    "ROUTINE_DATA_CHOICE <- parameters$ROUTINE_DATA_CHOICE\n",
-    "USE_ADJUSTED_POPULATION <- parameters$USE_ADJUSTED_POPULATION\n",
-    "DISAGGREGATION_SELECTION <- parameters$DISAGGREGATION_SELECTION\n",
-    "CARESEEKING_FILE_PATH <- parameters$CARESEEKING_FILE_PATH"
    ]
   },
   {
@@ -229,16 +335,44 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "64215532",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# import DHIS2 shapes data\n",
-    "shapes_data <- tryCatch({ get_latest_dataset_file_in_memory(DATASET_DHIS2, paste0(COUNTRY_CODE, \"_shapes.geojson\")) }, \n",
-    "                  error = function(e) {\n",
-    "                      msg <- paste(\"Error while loading DHIS2 Shapes data for: \" , COUNTRY_CODE, conditionMessage(e))\n",
-    "                      cat(msg)\n",
-    "                      stop(msg)\n",
-    "                      })"
+    "shapes_data <- load_country_file_from_dataset(\n",
+    "    dataset_id = DATASET_DHIS2, \n",
+    "    country_code = COUNTRY_CODE, \n",
+    "    suffix = \"_shapes.geojson\" \n",
+    "    )\n",
+    "\n",
+    "# printdim(shapes_data) needs function from utils (currently not in snt_utils.r)\n",
+    "dim(shapes_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2d94c80",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Simplify shapes to make it easier to render (fewer points per polygon)\n",
+    "# Set dTolerance bigger to keep fewer points\n",
+    "shapes_data_stsimplified <- st_simplify(shapes_data, dTolerance = 1000) \n",
+    "# GP:make this more refined to somehow reduce points without losing too much shape \n",
+    "# (maybe use `rmapshaper::ms_simplify()` instead of `st_simplify()`) ... ?\n",
+    "\n",
+    "# ⚠️ GP: Silence this as user does not need to read this in the report ...\n",
+    "print(\"Simplifying shapes for faster rendering ...\")\n",
+    "print(paste0(\"Original shapes data points: \", sum(mapply(function(g) length(unlist(g)), sf::st_geometry(shapes_data))))) \n",
+    "print(paste0(\"Simplified shapes data points: \", sum(mapply(function(g) length(unlist(g)), sf::st_geometry(shapes_data_stsimplified)))))"
    ]
   },
   {
@@ -246,31 +380,54 @@
    "id": "59b5b68c",
    "metadata": {},
    "source": [
-    "#### 2.2. Pyramid\n",
-    "This is needed to add back the `*_NAME` cols to the main data <br>\n",
-    "(Because normally we only output tables with the `*_ID` cols)"
+    "#### 2.2. Pyramid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60aaeacc",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# This is needed to add back the `*_NAME` cols to the main data <br>\n",
+    "# (Because normally we only output tables with the `*_ID` cols)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a0c17f43-8825-44cf-a4a1-7ce0c25cee17",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "pyramid_data <- tryCatch({ get_latest_dataset_file_in_memory(DATASET_DHIS2, paste0(COUNTRY_CODE, \"_pyramid.parquet\")) }, \n",
-    "                  error = function(e) {\n",
-    "                      msg <- paste(\"Error while loading DHIS2 Shapes data for: \" , COUNTRY_CODE, conditionMessage(e))\n",
-    "                      cat(msg)\n",
-    "                      stop(msg)\n",
-    "                      })"
+    "pyramid_data <- load_country_file_from_dataset(\n",
+    "    dataset_id = DATASET_DHIS2, \n",
+    "    country_code = COUNTRY_CODE, \n",
+    "    suffix = \"_pyramid.parquet\" \n",
+    "    )\n",
+    "\n",
+    "# head(pyramid_data, 3)\n",
+    "dim(pyramid_data)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "72af5723",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Keep only relevant cols and rename them to match incidence data\n",
@@ -283,7 +440,7 @@
     "  ) %>%\n",
     "  distinct()\n",
     "\n",
-    "head(pyramid, 3)"
+    "# head(pyramid, 3)"
    ]
   },
   {
@@ -291,32 +448,44 @@
    "id": "866bca3b",
    "metadata": {},
    "source": [
-    "#### 2.3. Monthly cases\n",
-    "Needed for <b>coherence checks</b>:\n",
-    "* **TPR** at monthly level over time \n",
-    "    * Explain changes (or lack thereof) between Crude and Adj1\n",
-    "    * Useful to monitor resistance (or testing behaviour ... ?)\n",
+    "#### 2.3. Cas par mois\n",
+    "Nécessaire pour les vérifications de **cohérence**:\n",
+    "* **TPR** au niveau mensuel au fil du temps\n",
+    "    * Expliquer les changements (ou l'absence de changement) entre Brut et Adj1\n",
+    "    * Utile pour surveiller la résistance (ou le comportement de dépistage... ?)\n",
     "* **Reporting Rate**\n",
-    "    * Explain changes (or lack thereof) between Adj1 and Adj2\n",
-    "* **Indicators** coherence:\n",
+    "    * Expliquer les changements (ou l'absence de changement) entre Adj1 et Adj2\n",
+    "* Cohérence des **indicateurs** :\n",
     "    * SUSP > TEST\n",
     "    * TEST > CONF\n",
-    "    * ... (check and add more ...)\n",
-    "\n",
-    "\n",
-    "⚠️ Note: **Import** from 📁`/data/` folder (not OH Dataset) <br>"
+    "    * ... (vérifier et en ajouter d'autres...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc6d190b",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ⚠️ Note: **Import** from 📁`/data/` folder (not OH Dataset) <br>"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "37b613d1",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# Import monthly_cases data from  \n",
-    "\n",
-    "# file_path <- file.path(DATA_PATH, \"incidence\", paste0(COUNTRY_CODE, \"_monthly_cases.parquet\"))\n",
     "file_path <- file.path(INTERMEDIATE_DATA_PATH, paste0(COUNTRY_CODE, \"_monthly_cases.parquet\"))\n",
     "monthly_cases <- arrow::read_parquet(file_path)\n",
     "log_msg(paste0(\"Monthly cases data loaded from : \", file_path))\n",
@@ -329,22 +498,29 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bdd78b96",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Add _NAME cols by joining with pyramid_data\n",
-    "monthly_cases <- left_join(monthly_cases, pyramid)\n",
-    "#, by = join_by(ADM1_ID, ADM2_ID))"
+    "monthly_cases <- left_join(monthly_cases, pyramid, by = join_by(ADM1_ID, ADM2_ID))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "93c7ac24",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "head(monthly_cases, 3)"
+    "# head(monthly_cases, 3)"
    ]
   },
   {
@@ -352,29 +528,33 @@
    "id": "605af751",
    "metadata": {},
    "source": [
-    "#### 2.4. Yearly Incidence\n",
-    "Currently, **each execution of the Incidence pipeline adds a new file to the OH Dataset**, where the filename stores the choice of parameters used.<br>\n",
-    "This introduces the issue of having to chose the correct file to import.\n",
-    "\n",
-    "For this, we need to **resolve the correct filename**, based on:\n",
-    "1. Pipeline paramters (injected here as well): `COUNTRY_CODE`, `ROUTINE_DATA_CHOICE`\n",
-    "2. Context-derived parameter (based on filename of what available in Dataset): `REPORTING_RATE_METHOD`"
+    "#### 2.4. Incidence Annuelle"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "df00062c",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82bfec55",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
    "source": [
-    "**Note**: `REPORTING_RATE_METHOD` this is NOT a parameter!<br>\n",
-    "The method is derived based on what is available in the dataset `config_json$SNT_DATASET_IDENTIFIERS$DHIS2_REPORTING_RATE`"
+    "# **Note**: `REPORTING_RATE_METHOD` this is NOT a parameter!<br>\n",
+    "# The method is derived based on what is available in the dataset `config_json$SNT_DATASET_IDENTIFIERS$DHIS2_REPORTING_RATE`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "cce0c1bf",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Define dataset and file names (based on parameter)\n",
@@ -412,48 +592,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19f87fa2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "filename_to_import <- glue::glue(\n",
-    "    \"{COUNTRY_CODE}_incidence.parquet\"\n",
-    "  )\n",
-    "\n",
-    "log_msg(paste0(\"Importing yearly incidence data from file : \", filename_to_import))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "cad08af7-9233-4138-91b8-5b82ed546cec",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "yearly_incidence <- tryCatch({ get_latest_dataset_file_in_memory(DATASET_NAME, filename_to_import) }, \n",
-    "                  error = function(e) {\n",
-    "                      msg <- paste(\"Error while loading seasonality file for: \" , COUNTRY_CODE, conditionMessage(e))\n",
-    "                      cat(msg)\n",
-    "                      stop(msg)\n",
-    "                      })\n",
+    "yearly_incidence <- load_country_file_from_dataset(\n",
+    "    dataset_id = DATASET_NAME, \n",
+    "    country_code = COUNTRY_CODE, \n",
+    "    suffix = \"_incidence.parquet\" \n",
+    "    )\n",
     "\n",
     "dim(yearly_incidence)\n",
     "head(yearly_incidence, 3)"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e2098887",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
    "source": [
-    "## Plot settings"
+    "## Plot settings\n",
+    "### 🎨 Dynamic categories and color assignement"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "5a45ada9",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Define suffix for exporting final outputs (preserve selected disaggregation in filename)\n",
@@ -461,17 +641,15 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d9296a78",
-   "metadata": {},
-   "source": [
-    "### 🎨 Dynamic categories and color assignement"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "641a42ec",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
    "source": [
     "##### 1. Define breaks and labels"
    ]
@@ -480,13 +658,19 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5851885d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Safety code to avoid breaking if nothings is fund in json_metadata\n",
     "if (!exists(\"break_vals\") || is.null(break_vals) || length(break_vals) == 0) {\n",
-    "    log_msg(\"[WARNING] No break values found in SNT_metadata.json for INCIDENCE_CRUDE$SCALE. Using default values.\", \"warning\")\n",
+    "    # log_msg(\"[WARNING] No break values found in SNT_metadata.json for INCIDENCE_CRUDE$SCALE. Using default values.\", \"warning\")\n",
     "    break_vals <- c(100, 250, 450, 1000)\n",
+    "        log_msg(glue::glue(\"No break values found in SNT_metadata.json for INCIDENCE_CRUDE$SCALE. Using default values: {paste(break_vals, collapse = ', ')}\"), \n",
+    "        \"info\")\n",
     "}"
    ]
   },
@@ -494,7 +678,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "03806bba",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create the full set of cut points (0 to Infinity)\n",
@@ -508,7 +696,7 @@
     ")\n",
     "\n",
     "# Check\n",
-    "labels"
+    "# labels"
    ]
   },
   {
@@ -523,7 +711,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1c2d0136",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Count nr of breaks\n",
@@ -540,40 +732,37 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d765607f",
-   "metadata": {},
-   "source": [
-    "#### Define plot size"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f9c3af7",
-   "metadata": {},
+   "id": "7c6aa7a0",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "options(repr.plot.width = 20, repr.plot.height = 12)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5ced60a4",
-   "metadata": {},
-   "source": [
-    "#### Repeated text"
+    "# ⚠️ TEMP fix to handle older parameter `USE_ADJUSTED_POPULATION`\n",
+    "#  now replaced by `USE_TRANSFORMED_POPULATION`\n",
+    "if (exists(\"USE_ADJUSTED_POPULATION\")) {\n",
+    "    USE_TRANSFORMED_POPULATION <- USE_ADJUSTED_POPULATION\n",
+    "}"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "25646014",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
+    "# Repeated text embedded in plots\n",
     "plot_caption_n1 <- glue::glue(\"Méthode de calcul de N1: {N1_METHOD}.\")\n",
-    "plot_caption_adjpop <- glue::glue(\"Utilisation de la population ajustée: {USE_ADJUSTED_POPULATION}.\")\n",
+    "plot_caption_adjpop <- glue::glue(\"Utilisation de la population ajustée: {USE_TRANSFORMED_POPULATION}.\")\n",
     "plot_caption_routine <- glue::glue(\"Données de routine: {ROUTINE_DATA_CHOICE}.\")\n",
     "plot_caption_reporting_rate <- glue::glue(\"Taux de déclaration calculé selon la méthode : {REPORTING_RATE_METHOD}.\")\n",
     "plot_caption_csbfile <- glue::glue(\"Données CSB fournies par l'utilisateur (fichier) : {CARESEEKING_FILE_PATH}.\")\n",
@@ -586,7 +775,7 @@
     "    plot_caption_csbfile, \n",
     "    sep = \"\\n\"\n",
     ")\n",
-    "plot_caption"
+    "# plot_caption"
    ]
   },
   {
@@ -594,9 +783,21 @@
    "id": "1768642c-297e-4a9f-939d-4460c047761b",
    "metadata": {},
    "source": [
-    "## Coherence checks\n",
-    "\n",
-    "See Jira: https://bluesquare.atlassian.net/browse/SNT25-272"
+    "## Contrôles de cohérence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5511ea9d",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# See Jira: https://bluesquare.atlassian.net/browse/SNT25-272"
    ]
   },
   {
@@ -604,14 +805,19 @@
    "id": "ea339f92",
    "metadata": {},
    "source": [
-    "#### 1. TPR"
+    "#### 1. TPR\n",
+    "Taux de Positivité des Tests"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "3a4cb374",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Calculate yearly TPR to be added on top of the monthly TPR plots\n",
@@ -626,7 +832,7 @@
     "      TPR_yearly = ifelse(!is.na(CONF_yearly) & !is.na(TEST_yearly) & (TEST_yearly != 0), CONF_yearly / TEST_yearly, 1)\n",
     "    ) \n",
     "\n",
-    "head(monthly_cases_yearly)"
+    "# head(monthly_cases_yearly, 3)"
    ]
   },
   {
@@ -640,12 +846,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d34d2d0",
-   "metadata": {},
+   "id": "49c8e0e6",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "ggplot(monthly_cases_yearly) +\n",
+    "# ⚠️ TO BE MOVED TO UTILS (as a function) ...\n",
+    "# Code to calculate width and height of plots based on the number of unique years and ADM2 regions\n",
+    "\n",
+    "nr_unique_year <- length(unique(monthly_cases_yearly$YEAR))\n",
+    "calc_width <- max(10, nr_unique_year * 5)\n",
+    "\n",
+    "nr_unique_adm2 <- length(unique(monthly_cases_yearly$ADM2_ID))\n",
+    "# (max ggsave size: 50 inches = 127 cm)\n",
+    "calc_height <- min(126, ceiling(nr_unique_adm2 / 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d34d2d0",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plot <- ggplot(monthly_cases_yearly) +\n",
     "# Monthly TPR lines\n",
+    "  geom_hline(\n",
+    "    yintercept = 0,\n",
+    "    color = \"grey21\",\n",
+    "    linewidth = 0.5\n",
+    "  ) +\n",
+    "  geom_hline(\n",
+    "    yintercept = c(0.25, 0.5, 0.75, 1.0),\n",
+    "    color = \"grey69\",\n",
+    "    linewidth = 0.25\n",
+    "  ) +\n",
     "  geom_line(\n",
     "    aes(x = MONTH, y = TPR, group = ADM2_NAME),\n",
     "    color = \"grey21\",\n",
@@ -655,11 +897,6 @@
     "    switch = \"y\") +\n",
     "  scale_x_continuous(breaks = seq(1,12,1)) +\n",
     "  scale_y_continuous(labels = scales::percent_format(accuracy = 1L), limits = c(0, 1)) +\n",
-    "  geom_hline(\n",
-    "    yintercept = 0,\n",
-    "    color = \"grey21\",\n",
-    "    linewidth = 0.5\n",
-    "  ) +\n",
     "  labs(\n",
     "    title = \"Taux de Positivité des Tests (TPR) pour ADM2 et mois\"  ) +\n",
     "  theme_minimal() +\n",
@@ -669,80 +906,22 @@
     "    strip.placement = \"outside\",\n",
     "    strip.background = element_rect(fill = \"grey21\"),\n",
     "    strip.text = element_text(color = \"white\"),\n",
+    "    axis.text.x = element_text(angle = 90, vjust = 0.5),\n",
     "    axis.title.y = element_blank()\n",
     "  )\n",
     "\n",
+    "# Export plot with ggsave to figures_dir\n",
+    "plot_dir = file.path(FIGURES_PATH, glue::glue(\"TPR_monthly_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
     "ggsave(\n",
-    "    file.path(FIGURES_PATH, glue::glue(\"TPR_monthly_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "    create.dir = TRUE,\n",
-    "    bg = \"white\",\n",
-    "    units = \"cm\",\n",
-    "    width = 21,\n",
-    "    height = 29.7,\n",
-    "    dpi = 200)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cf87c6a4",
-   "metadata": {},
-   "source": [
-    "##### 1.2. TPR (monthly & yearly) over time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0004755f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "  filename = plot_dir,\n",
+    "  plot = plot,\n",
+    "  width = calc_width, \n",
+    "  height = calc_height, \n",
+    "  units = \"cm\", \n",
+    "  dpi = 200\n",
+    ") \n",
     "\n",
-    "# Add layer of yearly TPR on top (actually underneath) of monthly TPR\n",
-    "\n",
-    "ggplot(monthly_cases_yearly) +\n",
-    "# Yearly TPR lines\n",
-    "  geom_line(\n",
-    "    aes(x = MONTH, y = TPR_yearly, group = ADM2_NAME), \n",
-    "    color = \"grey21\",\n",
-    "    alpha = 0.25,\n",
-    "    linewidth = 0.5) +\n",
-    "# Monthly TPR lines\n",
-    "  geom_line(\n",
-    "    aes(x = MONTH, y = TPR, group = ADM2_NAME),\n",
-    "    color = \"grey21\",\n",
-    "    alpha = 0.75) +\n",
-    "  facet_grid(\n",
-    "    cols = vars(YEAR), rows = vars(ADM1_NAME),\n",
-    "    switch = \"y\") +\n",
-    "  scale_x_continuous(breaks = seq(1,12,1)) +\n",
-    "  scale_y_continuous(labels = scales::percent_format(accuracy = 1L), limits = c(0, 1)) +\n",
-    "  geom_hline(\n",
-    "    yintercept = 0,\n",
-    "    color = \"grey21\",\n",
-    "    linewidth = 0.5\n",
-    "  ) +\n",
-    "  labs(\n",
-    "    title = \"Taux de Positivité des Tests (TPR) pour ADM2 at pour mois et année\",\n",
-    "    subtitle = \"Les valeurs agrégées par année sont indiquées comme lignes horizontales.\") +\n",
-    "  theme_minimal() +\n",
-    "  theme(\n",
-    "    panel.grid.minor = element_blank(),\n",
-    "    panel.grid.major.y = element_blank(),\n",
-    "    strip.placement = \"outside\",\n",
-    "    strip.background = element_rect(fill = \"grey21\"),\n",
-    "    strip.text = element_text(color = \"white\"),\n",
-    "    axis.title.y = element_blank()\n",
-    "  )\n",
-    "\n",
-    "ggsave(\n",
-    "    file.path(FIGURES_PATH, glue::glue(\"TPR_monthly_yearly_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "    create.dir = TRUE,\n",
-    "    bg = \"white\",\n",
-    "    units = \"cm\",\n",
-    "    width = 21,\n",
-    "    height = 29.7,\n",
-    "    dpi = 200)"
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   },
   {
@@ -751,22 +930,56 @@
    "metadata": {},
    "source": [
     "#### 2. RR\n",
-    "For more detailas, check **report** notebooks for reporting rate of used method. Possible options:\n",
-    "* **Dataset**: pipelines/snt_dhis2_reporting_rate_dataset/reporting/outputs/**snt_dhis2_reporting_rate_dataset_report**\\_OUTPUT\\_\\*.ipynb\n",
-    "* **DataElement**: work in progress ...\n",
     "\n",
-    "⚠️⚠️⚠️ **TO DO**: align code here with report notebook pf reporting rate (use \"🎨 NEW dynamic colors & breaks\" approach) ⚠️⚠️⚠️"
+    "Taux de Rapportage.\n",
+    "\n",
+    "Pour plus de détails, consultez les cahiers **de rapport** du pipeline \"**A.4 DHIS2 Reporting Rate (Dataset)**\" ou \"**A.4 DHIS2 Reporting Rate (Data element)**\", selon la méthode de calcul du taux de déclaration utilisée.<br>\n",
+    "Options possibles :\n",
+    "* **Dataset**: pipelines/snt_dhis2_reporting_rate_dataset/reporting/outputs/**snt_dhis2_reporting_rate_dataset_report**\\_OUTPUT\\_\\*.ipynb\n",
+    "* **Data Element**: pipelines/snt_dhis2_reporting_rate_dataelement/reporting/outputs/**snt_dhis2_reporting_rate_dataelement_report**\\_OUTPUT\\_\\*.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31b81bc9",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ⚠️ THIS SHOULD BE MOVED TO RR PIPELINE report ... !"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cd4d492",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ⚠️ **TO DO**: align code here with report notebook pf reporting rate (use \"🎨 NEW dynamic colors & breaks\" approach)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "780802fd",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Tile plot faceted by YEAR\n",
-    "ggplot(data = monthly_cases) +\n",
+    "plot <- ggplot(data = monthly_cases) +\n",
     "  geom_tile(aes(x = MONTH,\n",
     "                y = forcats::fct_rev(ADM2_NAME),\n",
     "                # fill = REPORTING_RATE_CATEGORY\n",
@@ -798,7 +1011,8 @@
     "    plot.subtitle = element_text(margin=margin(0,0,20,0)),\n",
     "    legend.position = \"bottom\",\n",
     "    legend.key.height = unit(0.25, \"cm\"),\n",
-    "    axis.text.x = element_text(size = 7),\n",
+    "    axis.text.x = element_text(size = 7, angle = 90, vjust = 0.5, hjust = 1),\n",
+    "    axis.text.y = element_text(size = 7),\n",
     "    axis.title.y = element_blank(),\n",
     "    panel.grid.minor = element_blank(),\n",
     "    panel.grid.major = element_blank(),\n",
@@ -808,31 +1022,70 @@
     "  ) +\n",
     "  guides(fill = guide_legend(nrow = 1))\n",
     "\n",
-    "# Export plot as png\n",
+    "# Export plot with ggsave to figures_dir\n",
+    "plot_dir = file.path(FIGURES_PATH, glue::glue(\"ReportingRate_heatmap_monthly_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
     "ggsave(\n",
-    "    file.path(FIGURES_PATH, glue::glue(\"ReportingRate_heatmap_monthly_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "    create.dir = TRUE,\n",
-    "    bg = \"white\",\n",
-    "    units = \"cm\",\n",
-    "    width = 21,\n",
-    "    height = 29.7,\n",
-    "    dpi = 200)"
+    "  filename = plot_dir,\n",
+    "  plot = plot,\n",
+    "  width = calc_width, \n",
+    "  height = calc_height, \n",
+    "  units = \"cm\", \n",
+    "  dpi = 200\n",
+    ") \n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "693ae7a4",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "# Check on data completeness for REPORTING RATE data: \n",
-    "# check how many values of REPORTING_RATE are NA\n",
-    "na_count <- sum(is.na(monthly_cases$REPORTING_RATE))     \n",
-    "if (na_count > 0) {\n",
-    "    log_msg(glue(\"⚠️ Warning: Reporting Rate data contains {na_count} missing values (NA) in 'REPORTING_RATE' column.\"), \"warning\")\n",
-    "} else {\n",
-    "    log_msg(\"✅ Reporting Rate data contains no missing values (NA) in 'REPORTING_RATE' column.\")\n",
+    "# # Check on data completeness for REPORTING RATE data: \n",
+    "# # check how many values (and what proportion) of REPORTING_RATE are NA\n",
+    "# na_count <- sum(is.na(monthly_cases$REPORTING_RATE))\n",
+    "# na_prop <- na_count / nrow(monthly_cases)\n",
+    "# if (na_count > 0) {\n",
+    "#     log_msg(glue(\"⚠️ Warning: Reporting Rate data contains {na_count} missing values (NA) in 'REPORTING_RATE' column ({scales::percent(na_prop, accuracy = 0.1)}).\"), \"warning\")\n",
+    "# } else {\n",
+    "#     log_msg(\"✅ Reporting Rate data contains no missing values (NA) in 'REPORTING_RATE' column.\")\n",
+    "# }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c1b75f5",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Same check, broken down per YEAR\n",
+    "na_prop_by_year <- monthly_cases %>%\n",
+    "    group_by(YEAR) %>%\n",
+    "    summarise(\n",
+    "        na_count = sum(is.na(REPORTING_RATE)),\n",
+    "        n = n(),\n",
+    "        na_prop = na_count / n,\n",
+    "        .groups = \"drop\"\n",
+    "    )\n",
+    "\n",
+    "for (i in seq_len(nrow(na_prop_by_year))) {\n",
+    "    row <- na_prop_by_year[i, ]\n",
+    "    if (row$na_count > 0) {\n",
+    "        print(glue(\"⚠️ Warning: Year {row$YEAR} - Reporting Rate data contains {row$na_count} missing values (NA) in 'REPORTING_RATE' column ({scales::percent(row$na_prop, accuracy = 0.1)}).\"))\n",
+    "    } else {\n",
+    "        print(glue(\"✅ Year {row$YEAR} - Reporting Rate data contains no missing values (NA) in 'REPORTING_RATE' column.\"))\n",
+    "    }\n",
     "}"
    ]
   },
@@ -841,19 +1094,19 @@
    "id": "0dfbbd7a",
    "metadata": {},
    "source": [
-    "### 3. Coherence checks on Incidence: Scatter plots\n",
+    "### 3. Contrôles de cohérence sur l'incidence : Graphique en nuage de points\n",
     "\n",
-    "Logic: each level of adjustment should produce values that are greater (or equal) to the previous level.<br>\n",
+    "Logique : chaque niveau d'ajustement doit produire des valeurs supérieures (ou égales) à celles du niveau précédent.<br>\n",
     "\n",
-    "Namely:\n",
-    "* Crude <= Adj1\n",
-    "* Adj1 <= Adj2\n",
-    "* Adj2 <= Adj3\n",
+    "Plus précisément:\n",
+    "* Brut <= Adj1\n",
+    "* Ajusté1 <= Ajusté2\n",
+    "* Ajusté2 <= Ajusté3\n",
     "\n",
-    "Given than Crude, Adj1, Adj2, and Adj3 are calculated by aggregating `CONF`, `N1`, `N2`, and `N3` at ADM2 x YEAR, we can first verify that the relationship between these values is coherent. Namely, check if\n",
+    "Étant donné que les valeurs brutes, Ajusté1, Ajusté2 et Ajusté3 sont calculées en agrégeant `CONF`, `N1`, `N2` et `N3` au niveau ADM2 x ANNÉE, nous pouvons d’abord vérifier que la relation entre ces valeurs est cohérente. À propos, vérifier si\n",
     "* `CONF` <= `N1`\n",
-    "* `N1` <= `N2`\n",
-    "* `N2` <= `N3` "
+    "* `N1` ≤ `N2`\n",
+    "* `N2` ≤ `N3`"
    ]
   },
   {
@@ -861,15 +1114,19 @@
    "id": "26460827",
    "metadata": {},
    "source": [
-    "#### 3.1. Incidence \"metrics\"\n",
-    "Metrics used to calculate incidence: `CONF`, `N1`, `N2`, (and `N3`)"
+    "#### 3.1. Mesures d'incidence\n",
+    "Mesures utilisées pour calculer l'incidence: `CONF`, `N1`, `N2`, (et `N3`)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "82f9a64b",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# CONF vs N1 \n",
@@ -882,7 +1139,7 @@
     "    warning_text <- \"✔ All CONF values are less than or equal to N1.\"\n",
     "}\n",
     "\n",
-    "ggplot(data = monthly_cases) +\n",
+    "plot <- ggplot(data = monthly_cases) +\n",
     "  geom_abline(intercept = 0, slope = 1, linetype = \"dashed\", color = \"red\") +\n",
     "  geom_point(\n",
     "    aes(\n",
@@ -894,19 +1151,37 @@
     "    subtitle = \"N1 is expected to be greater or equal to CONF\",\n",
     "    caption = warning_text\n",
     "    ) +\n",
-    "  theme_minimal() +\n",
+    "  theme_minimal(base_size = 7) +\n",
     "  theme(\n",
     "    aspect.ratio = 1,\n",
     "    plot.caption.position = \"plot\",\n",
     "    plot.caption = element_text(hjust = 0)\n",
-    "  )"
+    "  )\n",
+    "\n",
+    "plot_dir <- file.path(FIGURES_PATH, glue::glue(\"CONF_vs_N1_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
+    "ggsave(\n",
+    "  filename = plot_dir, \n",
+    "  plot = plot, \n",
+    "  # width = 21, \n",
+    "  # height = 21, \n",
+    "  width = 10, \n",
+    "  height = 10, \n",
+    "  units = \"cm\", \n",
+    "  dpi = 200\n",
+    "  )\n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "e7044d1d",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# N1 > N2\n",
@@ -919,7 +1194,7 @@
     "    warning_text <- \"✔ All N1 values are less than or equal to N2.\"\n",
     "}\n",
     "\n",
-    "ggplot(data = monthly_cases) +\n",
+    "plot <- ggplot(data = monthly_cases) +\n",
     "  geom_abline(intercept = 0, slope = 1, linetype = \"dashed\", color = \"red\") +\n",
     "  geom_point(\n",
     "    aes(\n",
@@ -930,12 +1205,24 @@
     "       subtitle = \"N2 is expected to be greater or equal to N1.\",\n",
     "       caption = warning_text\n",
     "       ) +\n",
-    "  theme_minimal() +\n",
+    "  theme_minimal(base_size = 7) +\n",
     "  theme(\n",
     "    aspect.ratio = 1,\n",
     "    plot.caption.position = \"plot\",\n",
     "    plot.caption = element_text(hjust = 0)\n",
-    "  )"
+    "  )\n",
+    "\n",
+    "plot_dir <- file.path(FIGURES_PATH, glue::glue(\"N1_vs_N2_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
+    "ggsave(\n",
+    "  filename = plot_dir, \n",
+    "  plot = plot, \n",
+    "  width = 10, \n",
+    "  height = 10, \n",
+    "  units = \"cm\", \n",
+    "  dpi = 200\n",
+    "  )\n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   },
   {
@@ -951,7 +1238,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "caff3b82",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Add col to mark cases where INCIDENCE_ADJ_TESTING < INCIDENCE_CRUDE so that it is displayed in red in the plot\n",
@@ -969,7 +1260,7 @@
     "      )\n",
     "}\n",
     "\n",
-    "head(yearly_incidence_plot)"
+    "# head(yearly_incidence_plot)"
    ]
   },
   {
@@ -984,7 +1275,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7847b5e7",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create warning message if there are INCIDENCE_CRUDE values greater than INCIDENCE_ADJ_TESTING\n",
@@ -996,7 +1291,7 @@
     "}\n",
     "\n",
     "# Plot with points colored based on FLAG_CRUDE_VS_ADJTEST and faceted by YEAR\n",
-    "ggplot(data = yearly_incidence_plot) +\n",
+    "plot <- ggplot(data = yearly_incidence_plot) +\n",
     "  geom_abline(intercept = 0, slope = 1, linetype = \"dashed\", color = \"black\") +\n",
     "  geom_point(\n",
     "    aes(\n",
@@ -1016,24 +1311,27 @@
     "    subtitle = warning_text,\n",
     "    caption = plot_caption\n",
     "    ) +\n",
-    "  theme_minimal() +\n",
+    "  theme_minimal(base_size = 7) +\n",
     "  theme(\n",
     "    aspect.ratio = 1,\n",
     "    legend.position = \"none\",\n",
     "    strip.text = element_text(face = \"bold\", size = 10),\n",
+    "    axis.text.x = element_text(angle = 90),\n",
     "    panel.grid.minor = element_blank(),\n",
     "    plot.caption = element_text(size = 7, hjust = 0)\n",
     "  )\n",
     "\n",
-    "# Export plots as png\n",
+    "plot_dir <- file.path(FIGURES_PATH, glue::glue(\"Incidence_year_crude_vs_adj_testing_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
     "ggsave(\n",
-    "    file.path(FIGURES_PATH, glue::glue(\"Incidence_year_crude_vs_adj_testing_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "    create.dir = TRUE,\n",
-    "    bg = \"white\",\n",
-    "    units = \"cm\",\n",
-    "    width = 25,\n",
-    "    height = 12.5,\n",
-    "    dpi = 200)"
+    "  filename = plot_dir, \n",
+    "  plot = plot, \n",
+    "  width = calc_width, \n",
+    "  height = 21 / 2, \n",
+    "  units = \"cm\", \n",
+    "  dpi = 300\n",
+    "  )\n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   },
   {
@@ -1047,12 +1345,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "14b2e28d",
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# 🚨 Need to handle cases where `FLAG_*` is (all) `NA`s ... !!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7b25c459",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create warning message if there are INCIDENCE_ADJ_TESTING values greater than INCIDENCE_ADJ_REPORTING\n",
-    "incidence_adj1_greater_adj2_count <- sum(yearly_incidence_plot$FLAG_ADJTEST_VS_ADJREP, na.rm = TRUE)  \n",
+    "incidence_adj1_greater_adj2_count <- sum(yearly_incidence_plot$FLAG_ADJTEST_VS_ADJREP, na.rm = TRUE) \n",
     "if (incidence_adj1_greater_adj2_count > 0) {\n",
     "    warning_text <- glue(\"✘ Attention: il y a {incidence_adj1_greater_adj2_count} instances où INCIDENCE_ADJ_TESTING est supérieure à INCIDENCE_ADJ_REPORTING.\", \"warning\")\n",
     "} else {\n",
@@ -1060,7 +1376,7 @@
     "}\n",
     "\n",
     "# Plot with points colored based on FLAG_ADJTEST_VS_ADJREP and faceted by YEAR\n",
-    "ggplot(data = yearly_incidence_plot) +\n",
+    "plot <- ggplot(data = yearly_incidence_plot) +\n",
     "    geom_abline(intercept = 0, slope = 1, linetype = \"dashed\", color = \"black\") +\n",
     "    geom_point(\n",
     "        aes(\n",
@@ -1080,24 +1396,27 @@
     "        subtitle = warning_text,\n",
     "        caption = plot_caption\n",
     "        ) +\n",
-    "    theme_minimal() +\n",
+    "    theme_minimal(base_size = 7) +\n",
     "    theme(\n",
     "        aspect.ratio = 1,\n",
     "        legend.position = \"none\",\n",
     "        strip.text = element_text(face = \"bold\", size = 10),\n",
+    "        axis.text.x = element_text(angle = 90),\n",
     "        panel.grid.minor = element_blank(),\n",
     "        plot.caption = element_text(size = 7, hjust = 0)\n",
     "    )\n",
     "\n",
-    "# Export plots as png\n",
+    "plot_dir <- file.path(FIGURES_PATH, glue::glue(\"Incidence_year_adj_testing_vs_adj_reporting_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
     "ggsave(\n",
-    "    file.path(FIGURES_PATH, glue::glue(\"Incidence_year_adj_testing_vs_adj_reporting_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "    create.dir = TRUE,\n",
-    "    bg = \"white\",\n",
-    "    units = \"cm\",\n",
-    "    width = 25,\n",
-    "    height = 12.5,\n",
-    "    dpi = 200)"
+    "  filename = plot_dir, \n",
+    "  plot = plot, \n",
+    "  width = calc_width, \n",
+    "  height = 21 / 2, \n",
+    "  units = \"cm\", \n",
+    "  dpi = 300\n",
+    "  )\n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   },
   {
@@ -1112,7 +1431,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "35f9e871",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "if (\"INCIDENCE_ADJ_CARESEEKING\" %in% colnames(yearly_incidence) && any(!is.na(yearly_incidence$INCIDENCE_ADJ_CARESEEKING))) {\n",
@@ -1120,7 +1443,7 @@
     "    # Create warning message if there are INCIDENCE_ADJ_TESTING values greater than INCIDENCE_ADJ_CARESEEKING\n",
     "    incidence_adj2_greater_adj3_count <- sum(yearly_incidence$INCIDENCE_ADJ_TESTING > yearly_incidence$INCIDENCE_ADJ_CARESEEKING, na.rm = TRUE)  \n",
     "    if (incidence_adj2_greater_adj3_count > 0) {\n",
-    "       warning_text <- glue(\"✘ Attention: il y a {incidence_adj2_greater_adj3_count} instances où INCIDENCE_ADJ_TESTING est supérieure à INCIDENCE_ADJ_CARESEEKING.\", \"warning\")\n",
+    "       warning_text <- glue(\"✘ Attention: il y a {incidence_adj2_greater_adj3_count} instances où INCIDENCE_ADJ_TESTING est supérieure à INCIDENCE_ADJ_CARESEEKING.\")\n",
     "    } else {\n",
     "       warning_text <- \"✔ Toutes les valeurs INCIDENCE_ADJ_TESTING sont inférieures ou égales à INCIDENCE_ADJ_CARESEEKING.\"\n",
     "    }\n",
@@ -1146,7 +1469,7 @@
     "            subtitle = warning_text,\n",
     "            caption = plot_caption\n",
     "            ) +\n",
-    "        theme_minimal() +\n",
+    "        theme_minimal(base_size = 7) +\n",
     "        theme(\n",
     "            aspect.ratio = 1,\n",
     "            legend.position = \"none\",\n",
@@ -1155,17 +1478,17 @@
     "            plot.caption = element_text(size = 7, hjust = 0)\n",
     "        )\n",
     "\n",
-    "    print(p)\n",
-    "    \n",
-    "    # Export plots as png\n",
+    "    plot_dir <- file.path(FIGURES_PATH, glue::glue(\"Incidence_year_adj_testing_vs_adj_careseeking_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
     "    ggsave(\n",
-    "        file.path(FIGURES_PATH, glue::glue(\"Incidence_year_adj_testing_vs_adj_careseeking_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "        create.dir = TRUE,\n",
-    "        bg = \"white\",\n",
-    "        units = \"cm\",\n",
-    "        width = 25,\n",
-    "        height = 12.5,\n",
-    "        dpi = 200)\n",
+    "    filename = plot_dir, \n",
+    "    plot = plot, \n",
+    "    width = calc_width, \n",
+    "    height = 21 / 2, \n",
+    "    units = \"cm\", \n",
+    "    dpi = 300\n",
+    "    )\n",
+    "\n",
+    "    IRdisplay::display_png(file = plot_dir)\n",
     "\n",
     "}"
    ]
@@ -1190,7 +1513,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3effcced",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Step 1: Prepare long-form data\n",
@@ -1225,7 +1552,7 @@
     "\n",
     "\n",
     "# Step 2: Join with shapefile\n",
-    "map_data_long <- shapes_data %>%\n",
+    "map_data_long <- shapes_data_stsimplified %>%\n",
     "  left_join(incidence_long, by = \"ADM2_ID\")\n",
     "\n",
     "\n",
@@ -1246,11 +1573,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1c3619af",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
-    "options(repr.plot.width = 20, repr.plot.height = 12)\n",
-    "\n",
     "# Dynamically define subtitle text (handle `is.null(DISAGGREGATION_SELECTION)` so it disaplys TOTAL instead)\n",
     "if (is.null(DISAGGREGATION_SELECTION)) {    \n",
     "    subtitle_text <- \"Brute et ajustée selon les étapes OMS.\\nAucune désagrégation spécifique sélectionnée.\"\n",
@@ -1259,7 +1588,7 @@
     "}\n",
     "\n",
     "# Plot maps faceted by incidence type and year\n",
-    "ggplot(map_data_long) +\n",
+    "plot <- ggplot(map_data_long) +\n",
     "  geom_sf(aes(fill = INCIDENCE_CATEGORY), color = \"white\", size = 0.2) +\n",
     "  facet_grid(\n",
     "    rows = vars(incidence_type_label),\n",
@@ -1271,11 +1600,11 @@
     "    subtitle = subtitle_text,\n",
     "    caption = plot_caption\n",
     "  ) +\n",
-    "  theme_minimal(base_size = 14) +\n",
+    "  theme_minimal(base_size = 10) +\n",
     "  theme(\n",
-    "    strip.text = element_text(face = \"bold\", size = 12),\n",
-    "    plot.title = element_text(face = \"bold\", size = 16),\n",
-    "    plot.subtitle = element_text(size = 13),\n",
+    "    strip.text = element_text(face = \"bold\", size = 9),\n",
+    "    plot.title = element_text(face = \"bold\", size = 10),\n",
+    "    plot.subtitle = element_text(size = 9),\n",
     "    plot.caption = element_text(size = 7, hjust = 0),\n",
     "    legend.position = \"right\",\n",
     "    legend.justification = \"top\",\n",
@@ -1285,15 +1614,17 @@
     "    axis.ticks = element_blank(),\n",
     "  )\n",
     "\n",
-    "ggsave(\n",
-    "  file.path(FIGURES_PATH, \n",
-    "  glue::glue(\"Incidence_faceted_year_adjustment_{DISAGGREGATION_SELECTION_SUFFIX}.png\")),\n",
-    "  create.dir = TRUE,\n",
-    "  units = \"cm\",\n",
-    "  width = 31,\n",
-    "  height = 31,\n",
-    "  dpi = 200\n",
-    "  )"
+    "plot_dir <- file.path(FIGURES_PATH, glue::glue(\"Incidence_faceted_year_adjustment_{DISAGGREGATION_SELECTION_SUFFIX}.png\"))\n",
+    "  ggsave(\n",
+    "    filename = plot_dir, \n",
+    "    plot = plot, \n",
+    "    width = calc_width + 10, \n",
+    "    height = 31,\n",
+    "    units = \"cm\", \n",
+    "    dpi = 300\n",
+    "    )\n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)\n"
    ]
   },
   {
@@ -1308,7 +1639,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f6acf093",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# Summarize incidence_long by computing mean incidence per INCIDENCE_TYPE and ADM2_ID across all years\n",
@@ -1322,7 +1657,7 @@
     "        ) \n",
     "\n",
     "# Step 2: Join with shapefile\n",
-    "map_data_long_mean <- shapes_data %>%\n",
+    "map_data_long_mean <- shapes_data_stsimplified %>%\n",
     "  left_join(incidence_long_mean, by = \"ADM2_ID\")\n",
     "\n",
     "\n",
@@ -1345,7 +1680,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7e9ddfcc",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "subtitle_text_mean <- if (is.null(DISAGGREGATION_SELECTION)) {\n",
@@ -1355,7 +1694,7 @@
     "}\n",
     "\n",
     "# Plot maps faceted by incidence type\n",
-    "ggplot(map_data_long_mean) +\n",
+    "plot <- ggplot(map_data_long_mean) +\n",
     "  geom_sf(aes(fill = INCIDENCE_CATEGORY), color = \"white\", size = 0.2) +\n",
     "  facet_wrap(\n",
     "    ~incidence_type_label,\n",
@@ -1367,11 +1706,11 @@
     "    subtitle = subtitle_text_mean,\n",
     "    caption = plot_caption\n",
     "  ) +\n",
-    "  theme_minimal(base_size = 14) +\n",
+    "  theme_minimal(base_size = 10) +\n",
     "  theme(\n",
-    "    strip.text = element_text(face = \"bold\", size = 12),\n",
-    "    plot.title = element_text(face = \"bold\", size = 16),\n",
-    "    plot.subtitle = element_text(size = 13),\n",
+    "    strip.text = element_text(face = \"bold\", size = 9),\n",
+    "    plot.title = element_text(face = \"bold\", size = 12),\n",
+    "    plot.subtitle = element_text(size = 10),\n",
     "    plot.caption = element_text(size = 7, hjust = 0),\n",
     "    legend.position = \"right\",\n",
     "    legend.justification = \"top\",\n",
@@ -1384,16 +1723,18 @@
     "\n",
     "# Export plots as png\n",
     "YEAR_RANGE <- paste0(min(yearly_incidence$YEAR), \"-\", max(yearly_incidence$YEAR))\n",
-    "ggsave(\n",
-    "        file.path(FIGURES_PATH, \n",
-    "        glue::glue(\"Incidence_faceted_adjustment_{DISAGGREGATION_SELECTION_SUFFIX}_mean-{YEAR_RANGE}.png\")),\n",
-    "        create.dir = TRUE,\n",
-    "        bg = \"white\",\n",
-    "        units = \"cm\",\n",
-    "        width = 41,\n",
-    "        height = 21,\n",
-    "        dpi = 200\n",
-    ")"
+    "\n",
+    "plot_dir <- file.path(FIGURES_PATH, glue::glue(\"Incidence_faceted_adjustment_{DISAGGREGATION_SELECTION_SUFFIX}_mean-{YEAR_RANGE}.png\"))\n",
+    "  ggsave(\n",
+    "    filename = plot_dir, \n",
+    "    plot = plot, \n",
+    "    width = 45, \n",
+    "    height = 15,\n",
+    "    units = \"cm\", \n",
+    "    dpi = 300\n",
+    "    )\n",
+    "\n",
+    "IRdisplay::display_png(file = plot_dir)"
    ]
   }
  ],
@@ -1404,7 +1745,12 @@
    "name": "ir"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "4.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
GP (2026-08-21) stuff done in SNT25-618
- Change issue as not really duplicated ... https://bluesquare.atlassian.net/browse/SNT25-618 is SMALLER than the older one (JUST NOT BREAK AND FIGS SHOW UP OK)
- Code replaced by utils funs: a few more to be adde, but that requiers more work on SNT_utils.R (separate Jira)
- Cleaned up text and translated to French
- Updated a breaking hardcoded parameter `USE_ADJUSTED_POPULATION` -> `USE_TRANSFORMED_POPULATION`

-----
Remains ToDo:
- [in CODE nb!] Adj3 should be NA if Adj2 is NA ... ! 
  -> see: https://bluesquare.atlassian.net/browse/SNT25-646
- 🚨 Need to handle cases where `FLAG_*` is (all) `NA`s ... !!
      (this should be fixed by above point)
- Plots of RR should be MOVED to the RR pipeline report (not incidence)!!!
  (these were included here because incidence consumes RR and therefore RR affects results,
  but the RR plots are not really part of incidence reporting)
- Scatter plots (coherence) should be made with 📦{scattermore} (rasterized) for lighter figures

------
Code tested in:
- "SNT Testing" (COD)
- "NER SNT Process" (NER)
- "CMR SNT Process" (CMR)
- "BDI SNT Process" (BDI)